### PR TITLE
ci: replace docs index workflow

### DIFF
--- a/.github/workflows/docs-index.yml
+++ b/.github/workflows/docs-index.yml
@@ -1,8 +1,7 @@
-name: Update Docs Index
+name: Update Master Index
 on:
   push:
-    branches: [ main ]
-    paths: [ 'Docs/**' ]
+    branches: [ main ]        # runs on merges to main too
   workflow_dispatch:
 
 permissions:
@@ -13,46 +12,76 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Generate Docs/INDEX.md
+      - name: Generate repo-wide INDEX.md (and Docs/INDEX.md)
         env:
           REPO: ${{ github.repository }}
         run: |
           python3 - <<'PY'
           import os, urllib.parse
+
           REPO = os.environ['REPO']
-          ROOT = 'Docs'
-          os.makedirs(ROOT, exist_ok=True)
-          lines = ['# Docs Index\n']
+          def view_url(p): return f'https://github.com/{REPO}/blob/main/{urllib.parse.quote(p)}'
+          def raw_url(p):  return f'https://raw.githubusercontent.com/{REPO}/main/{urllib.parse.quote(p)}'
+          def tree_url(p): return f'https://github.com/{REPO}/tree/main/{urllib.parse.quote(p)}'
+
+          # --- Master repo index at ./INDEX.md ---
+          EXCLUDE_DIRS = {'.git', '.github', '.idea', '.vscode'}
+          ROOT = '.'
+
+          lines = ['# Repository Index\n']
           for base, dirs, files in os.walk(ROOT):
+            # skip excluded dirs anywhere in the path
+            if any(part in EXCLUDE_DIRS for part in os.path.relpath(base, ROOT).split(os.sep)):
+              dirs[:] = []  # don't descend further
+              continue
+
+            dirs[:] = sorted(dirs)
+            files = sorted(f for f in files if f != '.DS_Store')
+
+            rel = os.path.relpath(base, ROOT)
+            if rel == '.':
+              title = 'Repository'
+            else:
+              title = rel.replace(os.sep, '/')
+              lines.append(f'\n## {title}\n[Open folder]({tree_url(rel)})\n')
+
+            for f in files:
+              p = f if rel == '.' else f'{rel}/{f}'
+              # don't index the index files themselves to avoid loops
+              if p in ('INDEX.md', 'Docs/INDEX.md'): continue
+              p = p.replace(os.sep, '/')
+              lines.append(f'- **{os.path.basename(p)}** — [View]({view_url(p)}) · [Raw]({raw_url(p)})')
+
+          open('INDEX.md', 'w', encoding='utf-8').write('\n'.join(lines) + '\n')
+
+          # --- Optional: keep Docs/INDEX.md (subset) for convenience ---
+          DOCS = 'Docs'
+          if os.path.isdir(DOCS):
+            dlines = ['# Docs Index (auto)\n', '↩️ [Back to Repository Index](../INDEX.md)\n']
+            for base, dirs, files in os.walk(DOCS):
               dirs[:] = sorted(dirs)
               files = sorted(f for f in files if f not in ('INDEX.md','README.md','.DS_Store'))
-              rel = os.path.relpath(base, ROOT)
+              rel = os.path.relpath(base, DOCS)
               if rel != '.':
-                  lines.append(f'\n## {rel.replace(os.sep,"/")}\n')
+                dlines.append(f'\n## {rel.replace(os.sep,"/")}\n')
               for f in files:
-                  p = os.path.join(base,f).replace(os.sep,'/')
-                  view = f'https://github.com/{REPO}/blob/main/{urllib.parse.quote(p)}'
-                  raw  = f'https://raw.githubusercontent.com/{REPO}/main/{urllib.parse.quote(p)}'
-                  lines.append(f'- **{f}** — [View]({view}) · [Raw]({raw})')
-          with open(os.path.join(ROOT,'INDEX.md'),'w',encoding='utf-8') as w:
-              w.write('\n'.join(lines) + '\n')
+                p = os.path.join(base, f).replace(os.sep, '/')
+                dlines.append(f'- **{f}** — [View]({view_url(p)}) · [Raw]({raw_url(p)})')
+            open(os.path.join(DOCS, 'INDEX.md'), 'w', encoding='utf-8').write('\n'.join(dlines) + '\n')
           PY
 
       - name: Commit index if changed
         run: |
           set -e
-          # Show what was generated (debug)
-          echo "=== Generated Docs/INDEX.md preview ==="
-          head -n 50 Docs/INDEX.md || true
-          echo "======================================="
-
-          # If anything about this file changed or it is new, commit it.
-          if [ -n "$(git status --porcelain Docs/INDEX.md)" ]; then
+          CHANGED="$(git status --porcelain INDEX.md Docs/INDEX.md 2>/dev/null || true)"
+          if [ -n "$CHANGED" ]; then
             git config user.name "github-actions"
             git config user.email "actions@github.com"
-            git add Docs/INDEX.md
-            git commit -m "docs: auto-update Docs/INDEX.md [skip ci]" || echo "Nothing to commit"
+            git add INDEX.md Docs/INDEX.md 2>/dev/null || true
+            git commit -m "ci: refresh repository index [skip ci]" || echo "Nothing to commit"
             git push
           else
             echo "No index changes"


### PR DESCRIPTION
## Summary
- replace docs index workflow with repository-wide index generator

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b12dfa64608324901defc0991ae50c