### PR TITLE
Add runtime bootstrapper to auto-spawn IntroScreen

### DIFF
--- a/Assets/Scripts/Boot/IntroBootstrap.cs
+++ b/Assets/Scripts/Boot/IntroBootstrap.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+/// Ensures the temporary IntroScreen (Start/Quit) exists when the game boots,
+/// independent of scene setup or build order.
+/// </summary>
+public static class IntroBootstrap
+{
+    private static bool spawnedOnce;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void EnsureIntro()
+    {
+#if NO_INTRO
+        return;
+#endif
+        if (spawnedOnce)
+            return;
+
+        // If an IntroScreen already exists in the scene, do nothing.
+        if (Object.FindObjectOfType<IntroScreen>() != null)
+        {
+            spawnedOnce = true;
+            return;
+        }
+
+        // Otherwise, create one.
+        var go = new GameObject("IntroScreen (Auto)");
+        // Keep it alive across scene loads; the IntroScreen script can hide/clear itself on Start.
+        Object.DontDestroyOnLoad(go);
+        go.AddComponent<IntroScreen>();
+
+        spawnedOnce = true;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure an IntroScreen exists on startup by auto-spawning when necessary

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b14afbafb48324a0c567b00b6b0dd7