### PR TITLE
Use FindAnyObjectByType on newer Unity

### DIFF
--- a/Assets/Scripts/Boot/IntroBootstrap.cs
+++ b/Assets/Scripts/Boot/IntroBootstrap.cs
@@ -17,8 +17,13 @@ public static class IntroBootstrap
         if (spawnedOnce)
             return;
 
-        // If an IntroScreen already exists in the scene, do nothing.
-        if (Object.FindObjectOfType<IntroScreen>() != null)
+        // If an IntroScreen already exists in the scene (FindAnyObjectByType/FindObjectOfType), do nothing.
+#if UNITY_2022_2_OR_NEWER
+        var existing = Object.FindAnyObjectByType<IntroScreen>();
+#else
+        var existing = Object.FindObjectOfType<IntroScreen>();
+#endif
+        if (existing != null)
         {
             spawnedOnce = true;
             return;

--- a/CODE_SNAPSHOT.txt
+++ b/CODE_SNAPSHOT.txt
@@ -18,8 +18,13 @@ public static class IntroBootstrap
         if (spawnedOnce)
             return;
 
-        // If an IntroScreen already exists in the scene, do nothing.
-        if (Object.FindObjectOfType<IntroScreen>() != null)
+        // If an IntroScreen already exists in the scene (FindAnyObjectByType/FindObjectOfType), do nothing.
+#if UNITY_2022_2_OR_NEWER
+        var existing = Object.FindAnyObjectByType<IntroScreen>();
+#else
+        var existing = Object.FindObjectOfType<IntroScreen>();
+#endif
+        if (existing != null)
         {
             spawnedOnce = true;
             return;


### PR DESCRIPTION
## Summary
- use `Object.FindAnyObjectByType` when running on Unity 2022.2 or newer
- document API change in comment

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b14e5a37648324863836602a868a75