### PR TITLE
Fix ambiguous Object reference in Unity scripts

### DIFF
--- a/Assets/Scripts/Systems/SelectionController.cs
+++ b/Assets/Scripts/Systems/SelectionController.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
@@ -11,7 +10,7 @@ using UnityEngine.InputSystem;
 public class SelectionController : MonoBehaviour
 {
     public static SpritePawn Selected { get; private set; }
-    public static event Action<SpritePawn> OnSelectionChanged;
+    public static event System.Action<SpritePawn> OnSelectionChanged;
 
 #if ENABLE_INPUT_SYSTEM
     private InputAction _clickAction;

--- a/Assets/Scripts/Units/SpritePawn.cs
+++ b/Assets/Scripts/Units/SpritePawn.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using System;
 
 /// <summary>
 /// A simple SNES-style sprite pawn that patrols a rectangle within the camera view.
@@ -181,7 +180,7 @@ public class SpritePawn : MonoBehaviour
         var renderer = quadGO.GetComponent<MeshRenderer>();
         renderer.sharedMaterial = mat;
         var col = quadGO.GetComponent<Collider>();
-        if (col) Object.Destroy(col);
+        if (col) UnityEngine.Object.Destroy(col);
 
         // Scale quad to match pixel size / pixels-per-unit
         float worldW = (float)spriteWidthPx / Mathf.Max(1, pixelsPerUnit);
@@ -251,7 +250,7 @@ public class SpritePawn : MonoBehaviour
         ringGO.transform.localScale = new Vector3(scale, scale, 1f);
         var rr = ringGO.GetComponent<MeshRenderer>();
         rr.sharedMaterial = ringMat;
-        var rc = ringGO.GetComponent<Collider>(); if (rc) Destroy(rc);
+        var rc = ringGO.GetComponent<Collider>(); if (rc) UnityEngine.Object.Destroy(rc);
         ringGO.SetActive(false);
     }
 
@@ -279,9 +278,9 @@ public class SpritePawn : MonoBehaviour
     {
         // Prefer the procedural grid to keep the pawn on the grass.
 #if UNITY_2022_2_OR_NEWER
-        var grid = Object.FindAnyObjectByType<SimpleGridMap>();
+        var grid = UnityEngine.Object.FindAnyObjectByType<SimpleGridMap>();
 #else
-        var grid = Object.FindObjectOfType<SimpleGridMap>();
+        var grid = UnityEngine.Object.FindObjectOfType<SimpleGridMap>();
 #endif
         if (grid != null)
         {


### PR DESCRIPTION
## Summary
- remove unnecessary `using System` in SpritePawn and SelectionController
- qualify UnityEngine.Object usages for collider removal and scene lookups
- fully qualify `System.Action` to avoid System namespace dependency

## Testing
- `dotnet test` *(command not found: dotnet)*
- `npm test` *(package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b165bcfb048324b2df63ae3cc4e49d