### PR TITLE
Add Selection HUD and control manager for pawn ownership

### DIFF
--- a/Assets/Scripts/Boot/SelectionBootstrap.cs
+++ b/Assets/Scripts/Boot/SelectionBootstrap.cs
@@ -22,6 +22,8 @@ public static class SelectionBootstrap
         var go = new GameObject("SelectionController (Auto)");
         Object.DontDestroyOnLoad(go);
         go.AddComponent<SelectionController>();
+        // HUD that draws the bottom-left info panel and right-side gizmos
+        go.AddComponent<SelectionHUD>();
         spawned = true;
     }
 }

--- a/Assets/Scripts/Systems/ControlManager.cs
+++ b/Assets/Scripts/Systems/ControlManager.cs
@@ -1,0 +1,37 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Global "assume control" ownership. Exactly one pawn can be controlled at a time.
+/// </summary>
+[AddComponentMenu("Systems/Control Manager")]
+public class ControlManager : MonoBehaviour
+{
+    public static SpritePawn Controlled { get; private set; }
+    public static event Action<SpritePawn> OnControlledChanged;
+
+    public static void AssumeControl(SpritePawn pawn)
+    {
+        if (pawn == null) return;
+        if (Controlled == pawn)
+        {
+            // Already controlled; no change but still raise event for listeners if needed.
+            try { OnControlledChanged?.Invoke(Controlled); } catch { }
+            return;
+        }
+        // Release previous
+        if (Controlled != null) Controlled.SetControlled(false);
+        Controlled = pawn;
+        Controlled.SetControlled(true);
+        try { OnControlledChanged?.Invoke(Controlled); } catch { }
+    }
+
+    public static void ReleaseControl()
+    {
+        if (Controlled == null) return;
+        Controlled.SetControlled(false);
+        Controlled = null;
+        try { OnControlledChanged?.Invoke(null); } catch { }
+    }
+}
+

--- a/Assets/Scripts/UI/SelectionHUD.cs
+++ b/Assets/Scripts/UI/SelectionHUD.cs
@@ -1,0 +1,109 @@
+using UnityEngine;
+
+/// <summary>
+/// Bottom-left info panel (blank for now) and a right-side gizmo strip.
+/// Appears only when a pawn is selected. First gizmo: Assume Control / Release.
+/// </summary>
+[AddComponentMenu("UI/Selection HUD")]
+public class SelectionHUD : MonoBehaviour
+{
+    [Header("Layout")]
+    [SerializeField] private Vector2 panelMinMaxW = new Vector2(260f, 420f);
+    [SerializeField] private Vector2 panelMinMaxH = new Vector2(130f, 220f);
+    [SerializeField] private float panelWidthPct = 0.28f; // of screen width
+    [SerializeField] private float panelHeightPct = 0.22f; // of screen height
+    [SerializeField] private float margin = 12f;
+    [SerializeField] private float gizmoSpacing = 8f;
+    [SerializeField] private float buttonHeightPct = 0.055f; // of screen height
+
+    private GUIStyle _panelStyle;
+    private GUIStyle _headerStyle;
+    private GUIStyle _buttonStyle;
+    private GUIStyle _labelStyle;
+
+    private void OnGUI()
+    {
+        var selected = SelectionController.Selected;
+        if (selected == null) return;
+
+        float sw = Screen.width;
+        float sh = Screen.height;
+
+        // Sizing
+        float panelW = Mathf.Clamp(sw * panelWidthPct, panelMinMaxW.x, panelMinMaxW.y);
+        float panelH = Mathf.Clamp(sh * panelHeightPct, panelMinMaxH.x, panelMinMaxH.y);
+        float btnH = Mathf.Max(28f, sh * buttonHeightPct);
+
+        // Panel rect (bottom-left anchor)
+        var panelRect = new Rect(margin, sh - panelH - margin, panelW, panelH);
+
+        // Gizmo strip to the right of the panel
+        var gizmoRect = new Rect(panelRect.xMax + gizmoSpacing, panelRect.y, 0f, panelRect.height);
+
+        EnsureStyles(sh);
+
+        // Draw panel (blank content for now; just a header for visual structure)
+        GUILayout.BeginArea(panelRect, GUIContent.none, _panelStyle);
+        {
+            GUILayout.Label("Unit Info", _headerStyle);
+            GUILayout.Space(btnH * 0.2f);
+            // Blank content placeholder
+            GUILayout.Label("(Coming soon)", _labelStyle);
+            GUILayout.FlexibleSpace();
+        }
+        GUILayout.EndArea();
+
+        // Gizmos
+        GUILayout.BeginArea(new Rect(gizmoRect.x, gizmoRect.y, Mathf.Max(160f, sw * 0.15f), gizmoRect.height));
+        {
+            // Assume/Release Control
+            bool isControlled = (ControlManager.Controlled == selected);
+            string btn = isControlled ? "Release Control" : "Assume Control";
+            if (GUILayout.Button(btn, _buttonStyle, GUILayout.Height(btnH)))
+            {
+                if (isControlled) ControlManager.ReleaseControl();
+                else ControlManager.AssumeControl(selected);
+            }
+
+            GUILayout.Space(btnH * 0.25f);
+            GUILayout.Label("Tip: WASD/Arrows to move when controlled.\nSpace = Pause. 1/2/3 = Speed.", _labelStyle);
+        }
+        GUILayout.EndArea();
+    }
+
+    void EnsureStyles(float sh)
+    {
+        if (_panelStyle == null)
+        {
+            _panelStyle = new GUIStyle(GUI.skin.box)
+            {
+                padding = new RectOffset(12, 12, 10, 10)
+            };
+        }
+        if (_headerStyle == null)
+        {
+            _headerStyle = new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleLeft,
+                fontSize = Mathf.Max(14, Mathf.RoundToInt(sh * 0.028f)),
+                fontStyle = FontStyle.Bold
+            };
+        }
+        if (_buttonStyle == null)
+        {
+            _buttonStyle = new GUIStyle(GUI.skin.button)
+            {
+                fontSize = Mathf.Max(12, Mathf.RoundToInt(sh * 0.024f))
+            };
+        }
+        if (_labelStyle == null)
+        {
+            _labelStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = Mathf.Max(11, Mathf.RoundToInt(sh * 0.02f)),
+                wordWrap = true
+            };
+        }
+    }
+}
+

--- a/Assets/Scripts/Units/SpritePawn.cs
+++ b/Assets/Scripts/Units/SpritePawn.cs
@@ -42,6 +42,7 @@ public class SpritePawn : MonoBehaviour
     private GameObject ringGO;
     private Material ringMat;
     private bool isSelected;
+    private bool isControlled;
 
     private void Awake()
     {
@@ -258,10 +259,28 @@ public class SpritePawn : MonoBehaviour
         ringGO.SetActive(false);
     }
 
+    public void SetControlled(bool on)
+    {
+        isControlled = on;
+        // Visual cue: brighten the ring if controlled
+        if (ringGO != null && ringMat != null)
+        {
+            // Slightly larger & brighter while controlled
+            float worldW = (float)spriteWidthPx / Mathf.Max(1, pixelsPerUnit);
+            float scale = worldW * (on ? 1.9f : 1.6f);
+            ringGO.transform.localScale = new Vector3(scale, scale, 1f);
+
+            var col = ringColor;
+            if (on) col = Color.Lerp(ringColor, Color.white, 0.3f);
+            if (ringMat.HasProperty("_Color")) ringMat.SetColor("_Color", col);
+            if (ringMat.HasProperty("_BaseColor")) ringMat.SetColor("_BaseColor", col);
+        }
+    }
+
     public void SetSelected(bool on)
     {
         isSelected = on;
-        if (ringGO != null) ringGO.SetActive(on);
+        if (ringGO != null) ringGO.SetActive(on || isControlled);
     }
 
     bool InsideBody(int x, int y, int x0, int x1, int y0, int y1)


### PR DESCRIPTION
## Summary
- Spawn a SelectionHUD alongside SelectionController to show a unit info panel and gizmo strip
- Introduce ControlManager for single-pawn ownership and new UI actions
- Let SpritePawn display a controlled state with brighter, enlarged ring

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories unsigned/403)*

------
https://chatgpt.com/codex/tasks/task_e_68b16ac997bc832495e7552c33e49f9e