### PR TITLE
Add mouse-wheel zoom for free camera and improve clamping

### DIFF
--- a/Assets/Scripts/Camera/FreeCameraController.cs
+++ b/Assets/Scripts/Camera/FreeCameraController.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 #endif
+// ReSharper disable Unity.InefficientPropertyAccess
+// ReSharper disable Unity.PerformanceCriticalCodeInvocation
 
 /// <summary>
 /// WASD/Arrow camera panning when no pawn is controlled.
@@ -15,19 +17,32 @@ public class FreeCameraController : MonoBehaviour
     [SerializeField] private float boostMultiplier = 2f;
     [SerializeField] private bool clampToGrid = true;
     [SerializeField] private float clampMargin = 1f;
+    
+    [Header("Zoom")]
+    [SerializeField] private float minOrtho = 3f;
+    [SerializeField] private float maxOrtho = 60f;
+    [SerializeField] private float zoomSpeed = 8f;          // how fast orthographicSize changes per wheel notch
+    [SerializeField] private bool smoothZoom = true;
+    [SerializeField] private float zoomSmoothTime = 0.08f;  // unscaled seconds
 
     private Camera _cam;
     private SimpleGridMap _grid;
+    private float _targetOrtho;
+    private float _zoomVel;
+    private float _skipClampUntil; // unscaled time
 
 #if ENABLE_INPUT_SYSTEM
     private InputAction _move;
     private InputAction _boost;
+    private InputAction _scroll;
 #endif
 
     private void Awake()
     {
         _cam = GetComponent<Camera>();
         if (_cam == null) _cam = Camera.main;
+        if (_cam != null)
+            _targetOrtho = Mathf.Max(0.01f, _cam.orthographicSize);
     }
 
     private void TryFindGrid()
@@ -58,14 +73,25 @@ public class FreeCameraController : MonoBehaviour
         {
             _boost = new InputAction("CamBoost", binding: "<Keyboard>/shift");
         }
+        if (_scroll == null)
+        {
+            _scroll = new InputAction("CamScroll", binding: "<Mouse>/scroll"); // Vector2 (x,y)
+        }
         _move.Enable();
         _boost.Enable();
+        _scroll.Enable();
+
+        ControlManager.OnControlledChanged += OnControlledChanged;
+        if (_cam != null)
+            _targetOrtho = Mathf.Max(0.01f, _cam.orthographicSize);
     }
 
     private void OnDisable()
     {
         _move?.Disable();
         _boost?.Disable();
+        _scroll?.Disable();
+        ControlManager.OnControlledChanged -= OnControlledChanged;
     }
 #endif
 
@@ -75,10 +101,28 @@ public class FreeCameraController : MonoBehaviour
         if (ControlManager.Controlled != null) return;
         if (_cam == null) return;
 
+        // --- Read inputs (move & zoom) ---
         Vector2 input = ReadMoveInput();
         if (input.sqrMagnitude > 1f) input.Normalize();
         bool boost = ReadBoost();
+        float scrollDelta = ReadScrollDelta(); // >0 means wheel up
 
+        // --- Zoom (center-based) ---
+        if (Mathf.Abs(scrollDelta) > 0.0001f)
+        {
+            // Wheel up (positive) -> zoom in -> smaller ortho size
+            _targetOrtho = Mathf.Clamp(_targetOrtho - scrollDelta * zoomSpeed, minOrtho, maxOrtho);
+        }
+        if (smoothZoom)
+        {
+            _cam.orthographicSize = Mathf.SmoothDamp(_cam.orthographicSize, _targetOrtho, ref _zoomVel, Mathf.Max(0.0001f, zoomSmoothTime), Mathf.Infinity, Time.unscaledDeltaTime);
+        }
+        else
+        {
+            _cam.orthographicSize = _targetOrtho;
+        }
+
+        // --- Pan (WASD/Arrows) ---
         float speed = moveSpeed * (boost ? boostMultiplier : 1f);
         Vector3 delta = new Vector3(input.x, 0f, input.y) * speed * Time.unscaledDeltaTime;
         Vector3 pos = _cam.transform.position + delta;
@@ -86,13 +130,20 @@ public class FreeCameraController : MonoBehaviour
         if (clampToGrid)
         {
             TryFindGrid();
-            if (_grid != null)
+            if (_grid != null && Time.unscaledTime >= _skipClampUntil)
             {
                 ClampToGrid(ref pos, _cam, _grid, clampMargin);
             }
         }
 
         _cam.transform.position = pos;
+    }
+
+    private void OnControlledChanged(SpritePawn pawn)
+    {
+        // When control is released (pawn == null), give a short grace window so clamp doesn't snap us.
+        if (pawn == null)
+            _skipClampUntil = Time.unscaledTime + 0.25f;
     }
 
     private static void ClampToGrid(ref Vector3 camPos, Camera cam, SimpleGridMap grid, float margin)
@@ -106,33 +157,20 @@ public class FreeCameraController : MonoBehaviour
 
         // Subtract half view so camera doesn't show outside the grid.
         float halfH = cam.orthographicSize;
-        float halfW = halfH * ((Screen.height > 0) ? (Screen.width / (float)Screen.height) : (16f / 9f));
+        float aspect = (Screen.height > 0) ? (Screen.width / (float)Screen.height) : (16f / 9f);
+        float halfW = halfH * aspect;
 
         float clampMinX = minX + halfW;
         float clampMaxX = maxX - halfW;
         float clampMinZ = minZ + halfH;
         float clampMaxZ = maxZ - halfH;
 
-        // If the grid is smaller than the viewport, center the camera.
-        if (clampMinX > clampMaxX)
-        {
-            float cx = (minX + maxX) * 0.5f;
-            camPos.x = cx;
-        }
-        else
-        {
-            camPos.x = Mathf.Clamp(camPos.x, clampMinX, clampMaxX);
-        }
+        // If the viewport is wider than the grid along an axis, skip clamping that axis (do NOT auto-center).
+        bool skipClampX = clampMinX > clampMaxX;
+        bool skipClampZ = clampMinZ > clampMaxZ;
 
-        if (clampMinZ > clampMaxZ)
-        {
-            float cz = (minZ + maxZ) * 0.5f;
-            camPos.z = cz;
-        }
-        else
-        {
-            camPos.z = Mathf.Clamp(camPos.z, clampMinZ, clampMaxZ);
-        }
+        if (!skipClampX) camPos.x = Mathf.Clamp(camPos.x, clampMinX, clampMaxX);
+        if (!skipClampZ) camPos.z = Mathf.Clamp(camPos.z, clampMinZ, clampMaxZ);
     }
 
     private Vector2 ReadMoveInput()
@@ -155,6 +193,19 @@ public class FreeCameraController : MonoBehaviour
         return _boost != null && _boost.IsPressed();
 #else
         return Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+#endif
+    }
+
+    private float ReadScrollDelta()
+    {
+#if ENABLE_INPUT_SYSTEM
+        // New Input System: mouse scroll is in "lines" per frame (y positive = scroll up)
+        if (_scroll == null) return 0f;
+        Vector2 v = _scroll.ReadValue<Vector2>();
+        return v.y;
+#else
+        // Legacy Input: positive y = scroll up
+        return Input.mouseScrollDelta.y;
 #endif
     }
 }


### PR DESCRIPTION
## Summary
- add mouse-wheel zoom, smooth orthographic sizing, and scroll input handling
- tweak camera clamping logic and add grace period after releasing control

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b17b63f2bc83248fa9ea7c9686b43f