### PR TITLE
Unify FreeCameraController lifecycle methods

### DIFF
--- a/Assets/Scripts/Camera/FreeCameraController.cs
+++ b/Assets/Scripts/Camera/FreeCameraController.cs
@@ -62,11 +62,8 @@ public class FreeCameraController : MonoBehaviour
         ControlManager.OnControlledChanged += OnControlledChanged;
         if (_cam != null)
             _targetOrtho = Mathf.Max(0.01f, _cam.orthographicSize);
-    }
 
 #if ENABLE_INPUT_SYSTEM
-    private void OnEnable()
-    {
         if (_move == null)
         {
             // 2D composite: WASD + Arrows + gamepad stick
@@ -78,28 +75,21 @@ public class FreeCameraController : MonoBehaviour
                 .With("Right", "<Keyboard>/d").With("Right", "<Keyboard>/rightArrow");
             _move.AddBinding("<Gamepad>/leftStick");
         }
-        if (_boost == null)
-        {
-            _boost = new InputAction("CamBoost", binding: "<Keyboard>/shift");
-        }
-        if (_scroll == null)
-        {
-            _scroll = new InputAction("CamScroll", binding: "<Mouse>/scroll"); // Vector2 (x,y)
-        }
-        _move.Enable();
-        _boost.Enable();
-        _scroll.Enable();
+        if (_boost == null) _boost = new InputAction("CamBoost", binding: "<Keyboard>/shift");
+        if (_scroll == null) _scroll = new InputAction("CamScroll", binding: "<Mouse>/scroll"); // Vector2 (x,y)
+        _move.Enable(); _boost.Enable(); _scroll.Enable();
+#endif
     }
 
     private void OnDisable()
     {
+        ControlManager.OnControlledChanged -= OnControlledChanged;
+#if ENABLE_INPUT_SYSTEM
         _move?.Disable();
         _boost?.Disable();
         _scroll?.Disable();
-    }
 #endif
-
-    private void OnDisable() { ControlManager.OnControlledChanged -= OnControlledChanged; }
+    }
 
     private void Update()
     {


### PR DESCRIPTION
## Summary
- Consolidate input-system setup into a single `OnEnable` and `OnDisable` for FreeCameraController
- Remove duplicate lifecycle implementations

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b17e758a388324a275f633727911b4