### PR TITLE
Add secondary pawn with Lissajous patrol

### DIFF
--- a/Assets/Scripts/Boot/PawnBootstrap.cs
+++ b/Assets/Scripts/Boot/PawnBootstrap.cs
@@ -27,8 +27,30 @@ public static class PawnBootstrap
 
         var pawnGO = new GameObject("TestPawn");
         pawnGO.transform.SetParent(root.transform, false);
-        pawnGO.AddComponent<SpritePawn>();
+        pawnGO.AddComponent<SpritePawn>(); // default pattern from component
         return pawnGO;
+    }
+
+    /// <summary>
+    /// Spawns a second pawn with a distinct movement pattern (figure-8 / Lissajous).
+    /// Safe to call multiple times; only creates if not already present.
+    /// </summary>
+    public static GameObject SpawnSecondPawn()
+    {
+        var root = GameObject.Find("World");
+        if (root == null)
+        {
+            root = new GameObject("World");
+        }
+        var existingGO = GameObject.Find("TestPawn_2");
+        if (existingGO != null) return existingGO;
+
+        var pawn2 = new GameObject("TestPawn_2");
+        pawn2.transform.SetParent(root.transform, false);
+        var sp = pawn2.AddComponent<SpritePawn>();
+        // Configure a clearly different walk pattern & speed.
+        sp.ConfigurePattern(SpritePawn.MovementPattern.Lissajous8, 2.4f);
+        return pawn2;
     }
 }
 

--- a/Assets/Scripts/UI/IntroScreen.cs
+++ b/Assets/Scripts/UI/IntroScreen.cs
@@ -127,6 +127,8 @@ public class IntroScreen : MonoBehaviour
         WorldBootstrap.GenerateDefaultGrid();
         // Spawn a SNES-style sprite pawn that patrols the visible area.
         PawnBootstrap.SpawnSpritePawn();
+        // Spawn a second pawn with a different walk pattern to test multi-unit behaviors.
+        PawnBootstrap.SpawnSecondPawn();
 
         showMenu = false;
         // The bootstrap GameObject is marked DontDestroyOnLoad, so we simply hide UI here.


### PR DESCRIPTION
## Summary
- spawn a second test pawn during intro startup
- extend PawnBootstrap with helper for figure-8 pawn
- add flexible movement patterns, including Lissajous/figure-8, and runtime configuration

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b183447d9c8324b67c05f40e01fe69