### PR TITLE
Enable sprint toggling and refine pawn interactions

### DIFF
--- a/Assets/Scripts/Systems/PawnInteractionManager.cs
+++ b/Assets/Scripts/Systems/PawnInteractionManager.cs
@@ -53,6 +53,10 @@ public class PawnInteractionManager : MonoBehaviour
                 float rad = (a.CollisionRadius + b.CollisionRadius) * 1.05f + extraRadiusPadding;
                 if (dist2 > rad * rad) continue;
 
+                // Sprinting cancels/ignores interactions (dash through)
+                if (a.IsSprinting || b.IsSprinting)
+                    continue;
+
                 // Decide leader/follower
                 SpritePawn leader, follower;
                 if (a.IsControlled && !b.IsControlled) { leader = a; follower = b; }


### PR DESCRIPTION
## Summary
- Allow controlled pawns to be considered interactable so they can initiate chats
- Add Shift-activated sprint mode for controlled movement with speed multiplier
- Skip interaction checks while either pawn is sprinting to allow dashing through

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b192360fd08324b857931bfc6c3b0a