### PR TITLE
Add season-based calendar and reposition clock HUD

### DIFF
--- a/Assets/Scripts/Boot/PauseBootstrap.cs
+++ b/Assets/Scripts/Boot/PauseBootstrap.cs
@@ -29,7 +29,8 @@ public static class PauseBootstrap
         }
 
         if (go.GetComponent<GameClock>() == null) go.AddComponent<GameClock>();
-        if (go.GetComponent<ClockHUD>() == null) go.AddComponent<ClockHUD>();
+        if (go.GetComponent<GameCalendar>() == null) go.AddComponent<GameCalendar>();
+        if (go.GetComponent<ClockHUD>() == null) go.AddComponent<ClockHUD>(); // draws under speed (top-right)
         spawned = true;
     }
 }

--- a/Assets/Scripts/Systems/GameCalendar.cs
+++ b/Assets/Scripts/Systems/GameCalendar.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public class SeasonDef
+{
+    public string name = "Season";
+    [Min(1)] public int days = 12;
+    public Color color = Color.white; // reserved for future UI lighting/themes
+}
+
+/// <summary>
+/// Lightweight calendar layered on top of GameClock. Supports custom seasons/lengths.
+/// Default year = 4 seasons × 12 days = 48 days.
+/// </summary>
+public class GameCalendar : MonoBehaviour
+{
+    [Header("Calendar Structure")]
+    [SerializeField] private List<SeasonDef> seasons = new List<SeasonDef>
+    {
+        new SeasonDef { name = "Spring", days = 12, color = new Color(0.6f, 0.9f, 0.6f) },
+        new SeasonDef { name = "Summer", days = 12, color = new Color(0.9f, 0.85f, 0.5f) },
+        new SeasonDef { name = "Autumn", days = 12, color = new Color(0.95f, 0.7f, 0.4f) },
+        new SeasonDef { name = "Winter", days = 12, color = new Color(0.8f, 0.9f, 1f) }
+    };
+
+    [Header("State (read-only)")]
+    [SerializeField] private int year = 1;       // starts at 1
+    [SerializeField] private int dayOfYear = 1;  // 1..DaysPerYear
+
+    public event Action<int> OnYearChanged;
+    public event Action<int> OnSeasonChanged; // passes SeasonIndex
+
+    public int Year => year;
+    public int DayOfYear => dayOfYear;
+    public int SeasonCount => Mathf.Max(1, seasons.Count);
+    public int DaysPerYear { get; private set; }
+
+    public int SeasonIndex
+    {
+        get
+        {
+            var (idx, _) = ResolveSeasonAndDay(dayOfYear);
+            return idx;
+        }
+    }
+
+    public string CurrentSeasonName => seasons.Count == 0 ? "Season" : seasons[SeasonIndex].name;
+
+    public int DayOfSeason
+    {
+        get
+        {
+            var (_, dayInSeason) = ResolveSeasonAndDay(dayOfYear);
+            return dayInSeason;
+        }
+    }
+
+    private GameClock _clock;
+
+    private void Awake()
+    {
+        RecomputeDaysPerYear();
+        dayOfYear = Mathf.Clamp(dayOfYear, 1, DaysPerYear);
+    }
+
+    private void OnEnable()
+    {
+        _clock = GameClockAPI.Find();
+        if (_clock != null) _clock.OnDayChanged += HandleDayAdvanced;
+    }
+
+    private void OnDisable()
+    {
+        if (_clock != null) _clock.OnDayChanged -= HandleDayAdvanced;
+        _clock = null;
+    }
+
+    private void HandleDayAdvanced(int newClockDay)
+    {
+        AdvanceOneDay();
+    }
+
+    public void ResetCalendar(int newYear, int newDayOfYear)
+    {
+        RecomputeDaysPerYear();
+        int prevSeason = SeasonIndex;
+        year = Mathf.Max(1, newYear);
+        dayOfYear = Mathf.Clamp(newDayOfYear, 1, DaysPerYear);
+        int nowSeason = SeasonIndex;
+        if (nowSeason != prevSeason) SafeInvokeSeasonChanged(nowSeason);
+    }
+
+    public void AdvanceOneDay()
+    {
+        int prevSeason = SeasonIndex;
+        dayOfYear++;
+        if (dayOfYear > DaysPerYear)
+        {
+            dayOfYear = 1;
+            year++;
+            SafeInvokeYearChanged(year);
+        }
+        int nowSeason = SeasonIndex;
+        if (nowSeason != prevSeason) SafeInvokeSeasonChanged(nowSeason);
+    }
+
+    private void RecomputeDaysPerYear()
+    {
+        if (seasons == null || seasons.Count == 0)
+        {
+            seasons = new List<SeasonDef> { new SeasonDef { name = "All-Year", days = 48 } };
+        }
+        int total = 0;
+        foreach (var s in seasons) total += Mathf.Max(1, s.days);
+        DaysPerYear = Mathf.Max(1, total);
+    }
+
+    private (int seasonIndex, int dayInSeason) ResolveSeasonAndDay(int dayOfYear1)
+    {
+        int d = Mathf.Clamp(dayOfYear1, 1, DaysPerYear);
+        int acc = 0;
+        for (int i = 0; i < seasons.Count; i++)
+        {
+            int len = Mathf.Max(1, seasons[i].days);
+            if (d <= acc + len)
+            {
+                int dayInSeason = d - acc; // 1-based
+                return (i, dayInSeason);
+            }
+            acc += len;
+        }
+        // Fallback
+        return (0, d);
+    }
+
+    private void SafeInvokeYearChanged(int y)
+    {
+        try { OnYearChanged?.Invoke(y); } catch { }
+    }
+
+    private void SafeInvokeSeasonChanged(int season)
+    {
+        try { OnSeasonChanged?.Invoke(season); } catch { }
+    }
+}
+
+public static class GameCalendarAPI
+{
+    public static GameCalendar Find() => UnityEngine.Object.FindObjectOfType<GameCalendar>();
+}
+

--- a/Assets/Scripts/UI/ClockHUD.cs
+++ b/Assets/Scripts/UI/ClockHUD.cs
@@ -1,43 +1,68 @@
 using UnityEngine;
 
 /// <summary>
-/// Minimal IMGUI overlay showing Day and 24h time (HH:MM). Placed at top-left.
+/// Minimal IMGUI overlay showing Year/Season/Day and 24h time (HH:MM).
+/// Rendered under the speed indicator at the top-right, slightly smaller.
 /// </summary>
 public class ClockHUD : MonoBehaviour
 {
-    [SerializeField] private Vector2 offset = new Vector2(12f, 12f);
-    [SerializeField] private float fontPct = 0.035f; // % of screen height
+    [Header("Layout")]
+    [SerializeField] private Vector2 topRightOffset = new Vector2(12f, 12f);
+    [SerializeField] private float fontPct = 0.032f; // slightly smaller than speed text
+    [SerializeField] private float extraTopOffsetPct = 0.040f; // approximate height of speed label + padding
 
     private GUIStyle _label;
+    private GUIStyle _shadow;
     private void Ensure()
     {
         if (_label == null)
         {
             _label = new GUIStyle(GUI.skin.label)
             {
-                alignment = TextAnchor.UpperLeft,
+                alignment = TextAnchor.UpperRight,
                 fontStyle = FontStyle.Bold
             };
             _label.normal.textColor = Color.white;
+        }
+        if (_shadow == null)
+        {
+            _shadow = new GUIStyle(_label);
+            _shadow.normal.textColor = new Color(0f, 0f, 0f, 0.6f);
         }
     }
 
     private void OnGUI()
     {
         var clock = GameClockAPI.Find();
-        if (clock == null) return;
+        if (clock == null) return; // nothing to show
+
+        var cal = GameCalendarAPI.Find();
 
         Ensure();
 
-        _label.fontSize = Mathf.RoundToInt(Mathf.Max(14f, Screen.height * fontPct));
-        string text = $"Day {clock.Day} — {clock.TimeHHMM}";
+        int fontSize = Mathf.RoundToInt(Mathf.Max(14f, Screen.height * fontPct));
+        _label.fontSize = fontSize;
+        _shadow.fontSize = fontSize;
 
-        // Shadow for legibility
-        Rect r = new Rect(offset.x, offset.y, Screen.width, Screen.height);
-        var shadow = new GUIStyle(_label);
-        shadow.normal.textColor = new Color(0f, 0f, 0f, 0.6f);
+        // Compose text: prefer calendar if available
+        string prefix;
+        if (cal != null)
+        {
+            prefix = $"Y{cal.Year} · {cal.CurrentSeasonName} {cal.DayOfSeason:00}";
+        }
+        else
+        {
+            prefix = $"Day {clock.Day:0}";
+        }
+        string text = $"{prefix} — {clock.TimeHHMM}";
+
+        // Layout: top-right, below speed label. We approximate the speed label height via extraTopOffsetPct.
+        float y = topRightOffset.y + Mathf.Max(24f, Screen.height * extraTopOffsetPct);
+        Rect r = new Rect(0f + topRightOffset.x, y, Screen.width - (topRightOffset.x * 2f), Screen.height);
+
+        // Shadow + main text
         Rect rShadow = new Rect(r.x + 1, r.y + 1, r.width, r.height);
-        GUI.Label(rShadow, text, shadow);
+        GUI.Label(rShadow, text, _shadow);
         GUI.Label(r, text, _label);
     }
 }

--- a/Assets/Scripts/UI/IntroScreen.cs
+++ b/Assets/Scripts/UI/IntroScreen.cs
@@ -196,6 +196,10 @@ public class IntroScreen : MonoBehaviour
         var clock = GameClockAPI.Find();
         if (clock != null) clock.ResetClock(1, 8, 0);
 
+        // Reset the calendar to Year 1, Day 1.
+        var cal = GameCalendarAPI.Find();
+        if (cal != null) cal.ResetCalendar(1, 1);
+
         showMenu = false;
     }
 }


### PR DESCRIPTION
## Summary
- add lightweight `GameCalendar` with seasons, year tracking, and events
- move the clock HUD beneath the speed indicator and show year/season/day
- ensure calendar is bootstrapped and reset when starting a new game

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a4c26b208324a7b260292f25bc13