### PR TITLE
Fix CS0618 warnings: use FindFirstObjectByType with fallback for older Unity

### DIFF
--- a/Assets/Scripts/Systems/GameCalendar.cs
+++ b/Assets/Scripts/Systems/GameCalendar.cs
@@ -148,6 +148,15 @@ public class GameCalendar : MonoBehaviour
 
 public static class GameCalendarAPI
 {
-    public static GameCalendar Find() => UnityEngine.Object.FindObjectOfType<GameCalendar>();
+    public static GameCalendar Find()
+    {
+#if UNITY_2023_1_OR_NEWER
+        // Prefer the modern API to avoid CS0618 warnings.
+        return UnityEngine.Object.FindFirstObjectByType<GameCalendar>();
+#else
+        // Fallback for older Unity versions.
+        return UnityEngine.Object.FindObjectOfType<GameCalendar>();
+#endif
+    }
 }
 

--- a/Assets/Scripts/Systems/GameClock.cs
+++ b/Assets/Scripts/Systems/GameClock.cs
@@ -105,5 +105,14 @@ public class GameClock : MonoBehaviour
 // Convenience static accessor if desired elsewhere.
 public static class GameClockAPI
 {
-    public static GameClock Find() => UnityEngine.Object.FindObjectOfType<GameClock>();
+    public static GameClock Find()
+    {
+#if UNITY_2023_1_OR_NEWER
+        // Prefer the modern API to avoid CS0618 warnings.
+        return UnityEngine.Object.FindFirstObjectByType<GameClock>();
+#else
+        // Fallback for older Unity versions.
+        return UnityEngine.Object.FindObjectOfType<GameClock>();
+#endif
+    }
 }


### PR DESCRIPTION
## Summary
- swap legacy FindObjectOfType with FindFirstObjectByType when available
- keep FindObjectOfType as a fallback for older Unity versions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a63fc0348324a4e8f656ae40d09d