### PR TITLE
Build Mode MVP with job system

### DIFF
--- a/Assets/Scripts/Boot/WorldBootstrap.cs
+++ b/Assets/Scripts/Boot/WorldBootstrap.cs
@@ -14,6 +14,15 @@ public static class WorldBootstrap
             root = new GameObject("World");
         }
 
+        // Ensure Buildings container exists so placed stations have a parent
+        var buildings = root.transform.Find("Buildings");
+        if (buildings == null)
+        {
+            var goBuild = new GameObject("Buildings");
+            goBuild.transform.SetParent(root.transform, false);
+            goBuild.transform.localPosition = Vector3.zero;
+        }
+
         // Create/find grid
         var grid = root.GetComponentInChildren<SimpleGridMap>();
         if (grid == null)

--- a/Assets/Scripts/Build/BuildBootstrap.cs
+++ b/Assets/Scripts/Build/BuildBootstrap.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public static class BuildBootstrap
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    public static void Ensure()
+    {
+        var go = GameObject.Find("BuildSystems (Auto)");
+        if (go == null)
+        {
+            go = new GameObject("BuildSystems (Auto)");
+        }
+
+        if (go.GetComponent<BuildModeController>() == null) go.AddComponent<BuildModeController>();
+        if (go.GetComponent<BuildPaletteHUD>() == null) go.AddComponent<BuildPaletteHUD>();
+        if (go.GetComponent<JobService>() == null) go.AddComponent<JobService>();
+    }
+}

--- a/Assets/Scripts/Build/BuildModeController.cs
+++ b/Assets/Scripts/Build/BuildModeController.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+
+public enum BuildTool
+{
+    None = 0,
+    PlaceConstructionBoard = 1,
+}
+
+public class BuildModeController : MonoBehaviour
+{
+    public static BuildModeController Instance { get; private set; }
+
+    [SerializeField] private bool isActive;
+    [SerializeField] private BuildTool currentTool = BuildTool.None;
+
+    public bool IsActive => isActive;
+    public BuildTool CurrentTool => currentTool;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this) { Destroy(gameObject); return; }
+        Instance = this;
+    }
+
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.B))
+        {
+            ToggleBuildMode();
+        }
+
+        // ESC cancels tool or exits build mode
+        if (isActive && Input.GetKeyDown(KeyCode.Escape))
+        {
+            if (currentTool != BuildTool.None)
+                SetTool(BuildTool.None);
+            else
+                SetActive(false);
+        }
+    }
+
+    public void ToggleBuildMode() => SetActive(!isActive);
+
+    public void SetActive(bool active)
+    {
+        isActive = active;
+        if (!isActive) SetTool(BuildTool.None);
+    }
+
+    public void SetTool(BuildTool tool)
+    {
+        currentTool = tool;
+        var toolComp = GetComponent<BuildPlacementTool>();
+        if (toolComp == null) toolComp = gameObject.AddComponent<BuildPlacementTool>();
+        toolComp.SetTool(tool);
+    }
+
+    public static bool UniqueBuildingExists<T>() where T : Building
+    {
+        // "Any" is acceptable and faster in 2023+; fallback for older Unity.
+#if UNITY_2023_1_OR_NEWER
+        return Object.FindAnyObjectByType<T>() != null;
+#else
+        return Object.FindObjectOfType<T>() != null;
+#endif
+    }
+}

--- a/Assets/Scripts/Build/BuildPaletteHUD.cs
+++ b/Assets/Scripts/Build/BuildPaletteHUD.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple build palette shown only while Build Mode is active.
+/// </summary>
+public class BuildPaletteHUD : MonoBehaviour
+{
+    [SerializeField] private Vector2 offset = new Vector2(12f, 120f);
+    [SerializeField] private float widthPct = 0.22f;
+
+    private GUIStyle _box;
+    private GUIStyle _button;
+    private GUIStyle _label;
+
+    private void Ensure()
+    {
+        if (_box == null)
+        {
+            _box = new GUIStyle(GUI.skin.box);
+        }
+        if (_button == null)
+        {
+            _button = new GUIStyle(GUI.skin.button)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontStyle = FontStyle.Bold
+            };
+        }
+        if (_label == null)
+        {
+            _label = new GUIStyle(GUI.skin.label) { alignment = TextAnchor.MiddleLeft, fontStyle = FontStyle.Bold };
+            _label.normal.textColor = Color.white;
+        }
+    }
+
+    private void OnGUI()
+    {
+        var bm = BuildModeController.Instance;
+        if (bm == null || !bm.IsActive) return;
+
+        Ensure();
+
+        float w = Mathf.Max(220f, Screen.width * widthPct);
+        Rect r = new Rect(offset.x, offset.y, w, Screen.height * 0.5f);
+        GUILayout.BeginArea(r, "Build Palette", _box);
+
+        GUILayout.Label("Stations", _label);
+        GUILayout.Space(6f);
+
+        // Construction Board entry
+        bool exists = BuildModeController.UniqueBuildingExists<ConstructionBoard>();
+        using (new GUILayout.HorizontalScope())
+        {
+            GUILayout.Label("Construction Board (Free)", GUILayout.ExpandWidth(true));
+            GUI.enabled = !exists;
+            if (GUILayout.Button(exists ? "Placed" : "Place", _button, GUILayout.Width(90f)))
+            {
+                bm.SetTool(BuildTool.PlaceConstructionBoard);
+            }
+            GUI.enabled = true;
+        }
+
+        GUILayout.FlexibleSpace();
+        GUILayout.Space(8f);
+        if (GUILayout.Button("Exit Build Mode (B)", _button, GUILayout.Height(32f)))
+        {
+            bm.SetActive(false);
+        }
+
+        GUILayout.EndArea();
+    }
+}
+
+internal struct GUIStateScope : System.IDisposable
+{
+    private readonly bool prev;
+    public GUIStateScope(bool enabled) { prev = GUI.enabled; GUI.enabled = enabled; }
+    public void Dispose() { GUI.enabled = prev; }
+}

--- a/Assets/Scripts/Jobs/JobService.cs
+++ b/Assets/Scripts/Jobs/JobService.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Central registry for job providers (buildings) and pawn job assignments.
+/// </summary>
+public class JobService : MonoBehaviour
+{
+    private class JobEntry
+    {
+        public int slots;
+        public readonly List<PawnJob> assigned = new List<PawnJob>();
+    }
+
+    // Building -> JobType -> JobEntry
+    private readonly Dictionary<Building, Dictionary<JobType, JobEntry>> _providers = new();
+
+    // All known pawns
+    private readonly List<PawnJob> _pawns = new();
+
+    public void RegisterPawn(PawnJob pj)
+    {
+        if (!_pawns.Contains(pj)) _pawns.Add(pj);
+    }
+
+    public void UnregisterPawn(PawnJob pj)
+    {
+        _pawns.Remove(pj);
+        foreach (var map in _providers.Values)
+        {
+            foreach (var e in map.Values)
+            {
+                e.assigned.Remove(pj);
+            }
+        }
+    }
+
+    public void SetSlots(Building b, JobType type, int slots)
+    {
+        if (b == null) return;
+        if (!_providers.TryGetValue(b, out var map))
+        {
+            map = new Dictionary<JobType, JobEntry>();
+            _providers[b] = map;
+        }
+        if (!map.TryGetValue(type, out var entry))
+        {
+            entry = new JobEntry();
+            map[type] = entry;
+        }
+        entry.slots = Mathf.Max(0, slots);
+
+        Rebalance(b, type, entry);
+    }
+
+    public List<PawnJob> AssignedFor(Building b, JobType type)
+    {
+        if (b == null) return new List<PawnJob>();
+        if (_providers.TryGetValue(b, out var map) && map.TryGetValue(type, out var e))
+        {
+            return e.assigned;
+        }
+        return new List<PawnJob>();
+    }
+
+    private void Rebalance(Building b, JobType type, JobEntry e)
+    {
+        // Remove overfill
+        while (e.assigned.Count > e.slots)
+        {
+            var pj = e.assigned[e.assigned.Count - 1];
+            e.assigned.RemoveAt(e.assigned.Count - 1);
+            if (pj != null && pj.AssignedBy == b) pj.SetJob(JobType.None, null);
+        }
+
+        // Fill underfill
+        if (e.assigned.Count < e.slots)
+        {
+            foreach (var pj in _pawns)
+            {
+                if (pj == null) continue;
+                if (!pj.IsIdle) continue;
+                e.assigned.Add(pj);
+                pj.SetJob(type, b);
+                if (e.assigned.Count >= e.slots) break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Jobs/JobType.cs
+++ b/Assets/Scripts/Jobs/JobType.cs
@@ -1,0 +1,10 @@
+public enum JobType
+{
+    None = 0,
+    Builder = 1,
+}
+
+public static class JobTypeExt
+{
+    public static string Name(this JobType t) => t.ToString();
+}

--- a/Assets/Scripts/Pawns/PawnJob.cs
+++ b/Assets/Scripts/Pawns/PawnJob.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+/// <summary>
+/// Minimal job holder for pawns; registers with JobService.
+/// </summary>
+public class PawnJob : MonoBehaviour
+{
+    [SerializeField] private JobType current = JobType.None;
+    [SerializeField] private Building assignedBy;
+
+    public bool IsIdle => current == JobType.None;
+    public JobType Current => current;
+    public Building AssignedBy => assignedBy;
+
+    private void OnEnable()
+    {
+        var js = FindObjectOfType<JobService>();
+        if (js != null) js.RegisterPawn(this);
+    }
+
+    private void OnDisable()
+    {
+        var js = FindObjectOfType<JobService>();
+        if (js != null) js.UnregisterPawn(this);
+    }
+
+    public void SetJob(JobType t, Building by)
+    {
+        current = t;
+        assignedBy = by;
+        name = gameObject.name; // keep name stable; could add suffix if desired
+    }
+}

--- a/Assets/Scripts/World/Building.cs
+++ b/Assets/Scripts/World/Building.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+/// <summary>
+/// Base component for placeable buildings.
+/// </summary>
+public class Building : MonoBehaviour
+{
+    public string id = "building";
+    public string displayName = "Building";
+    public bool uniquePerMap = false;
+    public Vector2Int size = Vector2Int.one; // tiles wide/high
+
+    [Header("Runtime")]
+    [SerializeField] protected Vector2Int gridPos; // bottom-left tile of footprint
+    [SerializeField] protected float tileSize = 1f;
+
+    public Vector2Int GridPos => gridPos;
+
+    public virtual void OnPlaced(Vector2Int grid, float tile)
+    {
+        gridPos = grid;
+        tileSize = tile;
+
+        // Add a collider for clicks if missing
+        var col = GetComponent<BoxCollider2D>();
+        if (col == null) col = gameObject.AddComponent<BoxCollider2D>();
+        col.size = new Vector2(size.x * tileSize, size.y * tileSize);
+        col.offset = Vector2.zero;
+    }
+
+    public virtual void OnRemoved() { }
+
+    public bool Occupies(Vector2Int tile)
+    {
+        return tile.x >= gridPos.x && tile.x < gridPos.x + size.x && tile.y >= gridPos.y && tile.y < gridPos.y + size.y;
+    }
+}

--- a/Assets/Scripts/World/Buildings/ConstructionBoard.cs
+++ b/Assets/Scripts/World/Buildings/ConstructionBoard.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// One-per-map station that offers the Builder job via slots.
+/// </summary>
+public class ConstructionBoard : Building
+{
+    [SerializeField, Min(0)] private int builderSlots = 1;
+    private bool _showInspector;
+
+    private void Start()
+    {
+        id = "construction_board";
+        displayName = string.IsNullOrEmpty(displayName) ? "Construction Board" : displayName;
+        uniquePerMap = true;
+        size = Vector2Int.one;
+    }
+
+    private void OnMouseUpAsButton()
+    {
+        _showInspector = !_showInspector;
+    }
+
+    public override void OnPlaced(Vector2Int grid, float tile)
+    {
+        base.OnPlaced(grid, tile);
+        var js = FindObjectOfType<JobService>();
+        if (js != null)
+        {
+            js.SetSlots(this, JobType.Builder, builderSlots);
+        }
+
+        // Visual stub: tint a quad so it's visible
+        var mr = GetComponent<MeshRenderer>();
+        if (mr == null)
+        {
+            var quad = GetComponent<MeshFilter>() == null ? GameObject.CreatePrimitive(PrimitiveType.Quad) : gameObject;
+            if (quad != gameObject)
+            {
+                quad.transform.SetParent(transform, false);
+                quad.transform.localPosition = Vector3.zero;
+            }
+            mr = GetComponentInChildren<MeshRenderer>();
+        }
+        if (mr != null)
+        {
+            if (mr.sharedMaterial == null) mr.sharedMaterial = new Material(Shader.Find("Sprites/Default"));
+            mr.sharedMaterial.color = new Color(0.95f, 0.85f, 0.35f, 1f);
+        }
+    }
+
+    private void OnGUI()
+    {
+        if (!_showInspector) return;
+
+        var js = FindObjectOfType<JobService>();
+        if (js == null) return;
+
+        Rect r = new Rect(20f, Screen.height * 0.6f, Mathf.Max(260f, Screen.width * 0.22f), Screen.height * 0.35f);
+        GUILayout.BeginArea(r, displayName, GUI.skin.window);
+
+        GUILayout.Label("Builder job", GUI.skin.label);
+        GUILayout.BeginHorizontal();
+        if (GUILayout.Button("-", GUILayout.Width(32f)))
+        {
+            builderSlots = Mathf.Max(0, builderSlots - 1);
+            js.SetSlots(this, JobType.Builder, builderSlots);
+        }
+        GUILayout.Label($"Slots: {builderSlots}", GUILayout.Width(120f));
+        if (GUILayout.Button("+", GUILayout.Width(32f)))
+        {
+            builderSlots = Mathf.Min(99, builderSlots + 1);
+            js.SetSlots(this, JobType.Builder, builderSlots);
+        }
+        GUILayout.EndHorizontal();
+
+        GUILayout.Space(6f);
+        var assigned = js.AssignedFor(this, JobType.Builder);
+        GUILayout.Label($"Assigned ({assigned.Count})");
+        int show = Mathf.Min(assigned.Count, 5);
+        for (int i = 0; i < show; i++)
+        {
+            GUILayout.Label($"- {assigned[i].name}");
+        }
+        if (assigned.Count > show)
+        {
+            GUILayout.Label($"...and {assigned.Count - show} more");
+        }
+
+        GUILayout.FlexibleSpace();
+        if (GUILayout.Button("Close")) _showInspector = false;
+        GUILayout.EndArea();
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap build systems and job service on load
- add build mode controller, palette UI, and placement tool
- introduce Construction Board building and basic job/slot system
- ensure world has a Buildings container

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ab1678d08324bdae904b0d8b7714