### PR TITLE
Improve build palette UI and B hotkey handling

### DIFF
--- a/Assets/Scripts/Build/BuildHotkeyListener.cs
+++ b/Assets/Scripts/Build/BuildHotkeyListener.cs
@@ -6,22 +6,38 @@ using UnityEngine;
 /// </summary>
 public class BuildHotkeyListener : MonoBehaviour
 {
-    private void Update()
+    private void Toggle()
     {
         if (IntroScreen.IsVisible) return; // ignore while at the intro menu
 
+        BuildBootstrap.Ensure();
+        var bm = BuildModeController.Instance;
+        if (bm == null)
+        {
+            var go = GameObject.Find("BuildSystems (Auto)");
+            if (go == null) go = new GameObject("BuildSystems (Auto)");
+            bm = go.GetComponent<BuildModeController>();
+            if (bm == null) bm = go.AddComponent<BuildModeController>();
+        }
+        bm.ToggleBuildMode();
+    }
+
+    private void Update()
+    {
         if (Input.GetKeyDown(KeyCode.B))
         {
-            BuildBootstrap.Ensure();
-            var bm = BuildModeController.Instance;
-            if (bm == null)
-            {
-                var go = GameObject.Find("BuildSystems (Auto)");
-                if (go == null) go = new GameObject("BuildSystems (Auto)");
-                bm = go.GetComponent<BuildModeController>();
-                if (bm == null) bm = go.AddComponent<BuildModeController>();
-            }
-            bm.ToggleBuildMode();
+            Toggle();
+        }
+    }
+
+    // Backstop for projects configured with the new Input System where GetKeyDown might be ignored
+    private void OnGUI()
+    {
+        var e = Event.current;
+        if (e != null && e.type == EventType.KeyDown && e.keyCode == KeyCode.B)
+        {
+            Toggle();
+            e.Use();
         }
     }
 }

--- a/Assets/Scripts/Build/BuildPaletteHUD.cs
+++ b/Assets/Scripts/Build/BuildPaletteHUD.cs
@@ -15,6 +15,8 @@ public class BuildPaletteHUD : MonoBehaviour
     private GUIStyle _button;
     private GUIStyle _label;
     private Vector2 _scroll;
+    private GUIStyle _itemLabel;
+    private GUIStyle _hint;
 
     private void Ensure()
     {
@@ -35,6 +37,16 @@ public class BuildPaletteHUD : MonoBehaviour
             _label = new GUIStyle(GUI.skin.label) { alignment = TextAnchor.MiddleLeft, fontStyle = FontStyle.Bold };
             _label.normal.textColor = Color.white;
         }
+        if (_itemLabel == null)
+        {
+            _itemLabel = new GUIStyle(GUI.skin.label) { alignment = TextAnchor.MiddleLeft };
+            _itemLabel.normal.textColor = Color.white;
+        }
+        if (_hint == null)
+        {
+            _hint = new GUIStyle(GUI.skin.label) { alignment = TextAnchor.MiddleLeft, fontStyle = FontStyle.Italic };
+            _hint.normal.textColor = new Color(1f, 1f, 1f, 0.85f);
+        }
     }
 
     private void OnGUI()
@@ -48,6 +60,9 @@ public class BuildPaletteHUD : MonoBehaviour
         int fontSize = Mathf.RoundToInt(Mathf.Max(14f, Screen.height * fontPct));
         _button.fontSize = fontSize;
         _label.fontSize = fontSize;
+        _itemLabel.fontSize = Mathf.RoundToInt(fontSize * 0.9f);
+        _hint.fontSize = Mathf.RoundToInt(fontSize * 0.85f);
+        _hint.wordWrap = true;
 
         float w = Mathf.Max(260f, Screen.width * widthPct);
         float h = Mathf.Max(260f, Screen.height * heightPct);
@@ -62,15 +77,24 @@ public class BuildPaletteHUD : MonoBehaviour
         bool exists = BuildModeController.UniqueBuildingExists<ConstructionBoard>();
         using (new GUILayout.HorizontalScope())
         {
-            GUILayout.Label("Construction Board (Free)", GUILayout.ExpandWidth(true));
+            GUILayout.Label("Construction Board (Free)", _itemLabel, GUILayout.ExpandWidth(true));
             GUI.enabled = !exists;
             float btnH = Mathf.Max(32f, Screen.height * buttonHPct);
-            if (GUILayout.Button(exists ? "Placed" : "Place", _button, GUILayout.Width(120f), GUILayout.Height(btnH)))
+            float btnW = Mathf.Max(120f, _button.CalcSize(new GUIContent(exists ? "Placed" : "Place")).x + 24f);
+            btnW = Mathf.Max(btnW, fontSize * 6f);
+            if (GUILayout.Button(exists ? "Placed" : "Place", _button, GUILayout.Width(btnW), GUILayout.Height(btnH)))
             {
                 bm.SetTool(BuildTool.PlaceConstructionBoard);
             }
             GUI.enabled = true;
         }
+
+        if (bm.CurrentTool == BuildTool.PlaceConstructionBoard)
+        {
+            GUILayout.Space(6f);
+            GUILayout.Label("Tip: Move the mouse to position the ghost. Left-click to place, Right-click to cancel.", _hint);
+        }
+
         GUILayout.EndScrollView();
 
         GUILayout.FlexibleSpace();


### PR DESCRIPTION
## Summary
- Refactor BuildHotkeyListener with a reusable Toggle method and an OnGUI backstop so the B hotkey works even with the new Input System
- Enhance BuildPaletteHUD readability with dedicated label styles, adaptive button width, and an instructional placement hint

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b4d6da048324916cb5302c1ca477