### PR TITLE
Fix camera lookup and remove unused field

### DIFF
--- a/Assets/Scripts/Build/BuildPlacementTool.cs
+++ b/Assets/Scripts/Build/BuildPlacementTool.cs
@@ -18,7 +18,6 @@ public class BuildPlacementTool : MonoBehaviour
     private float _tile = 1f; private int _w = 128; private int _h = 128;
     private Vector3 _gridMinWorld; // bottom-left world corner of tile (0,0)
     private bool _haveBounds;
-    private bool _assumeCentered;
 
     private Camera _cam;
     private static Sprite _whiteSprite;
@@ -225,18 +224,20 @@ public class BuildPlacementTool : MonoBehaviour
     private Camera GetCamera()
     {
         if (_cam != null) return _cam;
-#if UNITY_2023_1_OR_NEWER
-        _cam = Camera.main != null ? Camera.main : (Camera.GetAllCamerasCount() > 0 ? Camera.allCameras[0] : null);
-#else
-        _cam = Camera.main != null ? Camera.main : (Camera.allCamerasCount > 0 ? Camera.allCameras[0] : null);
-#endif
+        _cam = Camera.main;
+        if (_cam == null)
+        {
+            if (Camera.allCamerasCount > 0)
+            {
+                var arr = Camera.allCameras;
+                if (arr != null && arr.Length > 0) _cam = arr[0];
+            }
+        }
         return _cam;
     }
 
     private Vector3 GuessCenteredAnchor()
     {
-        // Assume grid is centered around (0,0) if no renderer bounds are found
-        _assumeCentered = true;
         return new Vector3(-_w * _tile * 0.5f, -_h * _tile * 0.5f, 0f);
     }
 


### PR DESCRIPTION
## Summary
- Simplify camera lookup to use `Camera.allCamerasCount`/`Camera.allCameras`
- Remove unused `_assumeCentered` flag in build placement

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fdbd0a388324a919909e1939ac55