### PR TITLE
Switch Construction Board to 3x1 horizontal orientation

### DIFF
--- a/Assets/Scripts/Build/BuildPlacementTool.cs
+++ b/Assets/Scripts/Build/BuildPlacementTool.cs
@@ -160,7 +160,7 @@ public class BuildPlacementTool : MonoBehaviour
                 var board = go.AddComponent<ConstructionBoard>();
                 board.displayName = "Construction Board";
                 board.uniquePerMap = true;
-                board.size = new Vector2Int(1, 3);
+                board.size = new Vector2Int(3, 1);
                 board.OnPlaced(_snapGridPos, _tile);
                 break;
             }
@@ -259,7 +259,7 @@ public class BuildPlacementTool : MonoBehaviour
     {
         switch (_tool)
         {
-            case BuildTool.PlaceConstructionBoard: return new Vector2Int(1, 3);
+            case BuildTool.PlaceConstructionBoard: return new Vector2Int(3, 1);
             default: return Vector2Int.one;
         }
     }

--- a/Assets/Scripts/World/Buildings/ConstructionBoard.cs
+++ b/Assets/Scripts/World/Buildings/ConstructionBoard.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 /// <summary>
 /// One-per-map station that offers the Builder job via slots.
-/// Footprint: 1x3 tiles (vertical), anchored at bottom-left.
+/// Footprint: 3x1 tiles (horizontal), anchored at bottom-left.
 /// </summary>
 public class ConstructionBoard : Building
 {
@@ -15,7 +15,7 @@ public class ConstructionBoard : Building
         id = "construction_board";
         displayName = string.IsNullOrEmpty(displayName) ? "Construction Board" : displayName;
         uniquePerMap = true;
-        size = new Vector2Int(1, 3);
+        size = new Vector2Int(3, 1);
     }
 
     private void OnMouseUpAsButton()
@@ -50,7 +50,7 @@ public class ConstructionBoard : Building
         {
             if (mr.sharedMaterial == null) mr.sharedMaterial = new Material(Shader.Find("Sprites/Default"));
             mr.sharedMaterial.color = new Color(0.95f, 0.85f, 0.35f, 1f);
-            // Scale to 1x3 footprint
+            // Scale to 3x1 footprint
             mr.transform.localScale = new Vector3(size.x * tileSize, size.y * tileSize, 1f);
             mr.transform.localPosition = new Vector3((size.x * tileSize) * 0.5f, (size.y * tileSize) * 0.5f, 0f);
         }


### PR DESCRIPTION
## Summary
- make Construction Board footprint 3x1 with horizontal orientation and adjust visuals
- update build placement tool for 3x1 footprint and preview

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b20357e15483249128c5efa63a164e