### PR TITLE
Switch placement & visuals to XZ world

### DIFF
--- a/Assets/Scripts/World/Building.cs
+++ b/Assets/Scripts/World/Building.cs
@@ -8,7 +8,7 @@ public class Building : MonoBehaviour
     public string id = "building";
     public string displayName = "Building";
     public bool uniquePerMap = false;
-    public Vector2Int size = Vector2Int.one; // tiles wide/high
+    public Vector2Int size = Vector2Int.one; // tiles wide (X) / deep (Z)
 
     [Header("Runtime")]
     [SerializeField] protected Vector2Int gridPos; // bottom-left tile of footprint
@@ -21,11 +21,13 @@ public class Building : MonoBehaviour
         gridPos = grid;
         tileSize = tile;
 
-        // Add a collider for clicks if missing
-        var col = GetComponent<BoxCollider2D>();
-        if (col == null) col = gameObject.AddComponent<BoxCollider2D>();
-        col.size = new Vector2(size.x * tileSize, size.y * tileSize);
-        col.offset = Vector2.zero;
+        // Add/adjust a 3D collider that sits on the XZ plane
+        var col3 = GetComponent<BoxCollider>();
+        if (col3 == null) col3 = gameObject.AddComponent<BoxCollider>();
+        float w = size.x * tileSize;
+        float d = size.y * tileSize;
+        col3.size = new Vector3(w, 0.1f, d);
+        col3.center = new Vector3(w * 0.5f, 0.05f, d * 0.5f);
     }
 
     public virtual void OnRemoved() { }

--- a/Assets/Scripts/World/Buildings/ConstructionBoard.cs
+++ b/Assets/Scripts/World/Buildings/ConstructionBoard.cs
@@ -37,7 +37,7 @@ public class ConstructionBoard : Building
             js.SetSlots(this, JobType.Builder, builderSlots);
         }
 
-        // Visual stub: tint a quad so it's visible
+        // Visual stub: quad rotated onto XZ so it's visible from top-down
         var mr = GetComponentInChildren<MeshRenderer>();
         if (mr == null)
         {
@@ -45,14 +45,17 @@ public class ConstructionBoard : Building
             quad.name = "BoardVisual";
             quad.transform.SetParent(transform, false);
             mr = quad.GetComponent<MeshRenderer>();
+            quad.transform.localRotation = Quaternion.Euler(-90f, 0f, 0f);
         }
         if (mr != null)
         {
             if (mr.sharedMaterial == null) mr.sharedMaterial = new Material(Shader.Find("Sprites/Default"));
             mr.sharedMaterial.color = new Color(0.95f, 0.85f, 0.35f, 1f);
-            // Scale to 3x1 footprint
-            mr.transform.localScale = new Vector3(size.x * tileSize, size.y * tileSize, 1f);
-            mr.transform.localPosition = new Vector3((size.x * tileSize) * 0.5f, (size.y * tileSize) * 0.5f, 0f);
+            // Scale to 3x1 footprint (X=width, Z=depth)
+            var t = mr.transform;
+            t.localRotation = Quaternion.Euler(-90f, 0f, 0f);
+            t.localScale = new Vector3(size.x * tileSize, size.y * tileSize, 1f);
+            t.localPosition = new Vector3((size.x * tileSize) * 0.5f, 0.01f, (size.y * tileSize) * 0.5f);
         }
     }
 


### PR DESCRIPTION
## Summary
- Raycast mouse to ground plane and snap placement on XZ grid with top-down orientation.
- Convert Building colliders to 3D box on XZ plane.
- Rotate Construction Board preview quad for top-down visibility.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2057b73f48324820dbe0a476a05f5