### PR TITLE
Handle XY/XZ grid placement

### DIFF
--- a/Assets/Scripts/Build/GridSpace.cs
+++ b/Assets/Scripts/Build/GridSpace.cs
@@ -1,0 +1,15 @@
+public enum GridPlane
+{
+    XY,
+    XZ
+}
+
+/// <summary>
+/// Global grid-space hint so placement/visuals/colliders can agree on the plane.
+/// </summary>
+public static class GridSpace
+{
+    public static GridPlane Plane = GridPlane.XY; // default to classic 2D
+}
+
+


### PR DESCRIPTION
## Summary
- add GridSpace enum to share world plane
- auto-detect XY vs XZ grid and orient placement/ghost accordingly
- add simple OnGUI debug overlay for placement diagnostics

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b209e490b88324b223312f88008498