### PR TITLE
Drive placement loop from Update for build placements

### DIFF
--- a/Assets/Scripts/Build/BuildPlacementTool.cs
+++ b/Assets/Scripts/Build/BuildPlacementTool.cs
@@ -46,26 +46,28 @@ public class BuildPlacementTool : MonoBehaviour
         EnsureGhost();
     }
 
-    private void LateUpdate()
+    private void Update()
     {
+        // Drive placement every frame
+        SyncToolFromController();
+
         if (_tool == BuildTool.None)
         {
             DestroyGhost();
             return;
         }
 
-        ReadGridInfo();
+        // Update ghost & validity continuously
         UpdateGhost();
 
-        if (Input.GetMouseButtonDown(1)) // cancel tool
-        {
-            SetTool(BuildTool.None);
-            return;
-        }
-
-        if (Input.GetMouseButtonDown(0)) // left-click to place
+        // Handle input
+        if (Input.GetMouseButtonDown(0))
         {
             TryPlace();
+        }
+        else if (Input.GetMouseButtonDown(1) || Input.GetKeyDown(KeyCode.Escape))
+        {
+            CancelPlacement();
         }
     }
 
@@ -125,6 +127,7 @@ public class BuildPlacementTool : MonoBehaviour
     {
         // Keep local tool state in sync with the controller every frame
         SyncToolFromController();
+        ReadGridInfo();
 
         if (_tool == BuildTool.None)
         {
@@ -411,6 +414,20 @@ public class BuildPlacementTool : MonoBehaviour
         foreach (var b in all)
             if (RectOverlaps(b.GridPos, b.size, _snapGridPos, _footSize)) return $"(overlap with {b.displayName})";
         return "";
+    }
+
+    private void CancelPlacement()
+    {
+        var bm = BuildModeController.Instance;
+        if (bm != null)
+        {
+            bm.SetTool(BuildTool.None);
+        }
+        else
+        {
+            SetTool(BuildTool.None);
+        }
+        DestroyGhost();
     }
 
     private void DestroyGhost()


### PR DESCRIPTION
## Summary
- Refresh build placement each frame in `Update` and handle click/escape input
- Keep grid data up to date in `UpdateGhost`
- Add helper to cancel placement and remove ghost

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b215443dec8324b131f83e017b1e68