### PR TITLE
Improve build placement info and single-tool bootstrap

### DIFF
--- a/Assets/Scripts/Build/BuildBootstrap.cs
+++ b/Assets/Scripts/Build/BuildBootstrap.cs
@@ -11,6 +11,11 @@ public static class BuildBootstrap
             go = new GameObject("BuildSystems (Auto)");
         }
 
+        // Ensure single placement tool
+        var tools = go.GetComponents<BuildPlacementTool>();
+        for (int i = 1; i < tools.Length; i++) Object.Destroy(tools[i]);
+        if (tools.Length == 0) go.AddComponent<BuildPlacementTool>();
+
         if (go.GetComponent<BuildModeController>() == null) go.AddComponent<BuildModeController>();
         if (go.GetComponent<BuildPaletteHUD>() == null) go.AddComponent<BuildPaletteHUD>();
         if (go.GetComponent<JobService>() == null) go.AddComponent<JobService>();


### PR DESCRIPTION
## Summary
- ensure there's only one BuildPlacementTool in the scene via bootstrap
- refresh grid data every frame and show raw-hit marker for placement
- enhance placement overlay with world and anchor info

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b21855ec3c83249eb2c8e39038cf38