### PR TITLE
Switch placement visuals to 2D SpriteRenderer on XY; auto-bootstrap on load; robust mouse diagnostics; marker/ghost as sprites

### DIFF
--- a/Assets/Scripts/Build/BuildBootstrap.cs
+++ b/Assets/Scripts/Build/BuildBootstrap.cs
@@ -3,7 +3,7 @@ using FantasyColony.Defs;
 
 public static class BuildBootstrap
 {
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)] private static void Auto() => Ensure();
     public static void Ensure()
     {
         var go = GameObject.Find("BuildSystems (Auto)");
@@ -25,5 +25,6 @@ public static class BuildBootstrap
 
         DefDatabase.LoadAll();
         VisualRegistry.Build(Application.isEditor);
+        SpriteVisualFactory2D.Build();
     }
 }

--- a/Assets/Scripts/Rendering/SpriteVisualFactory2D.cs
+++ b/Assets/Scripts/Rendering/SpriteVisualFactory2D.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using FantasyColony.Defs;
+using UnityEngine;
+
+public static class SpriteVisualFactory2D
+{
+    private static readonly Dictionary<string, GameObject> _ghostPrefabs = new();
+    private static readonly Dictionary<string, GameObject> _placedPrefabs = new();
+    private static Sprite _white;
+    private static string _sortingLayer;
+    private static int _orderGround;
+
+    public static void Build()
+    {
+        _ghostPrefabs.Clear();
+        _placedPrefabs.Clear();
+        EnsureWhiteSprite();
+        DetectSortingLayer();
+
+        foreach (var kv in DefDatabase.Visuals)
+        {
+            var v = kv.Value;
+            _ghostPrefabs[v.id] = MakeSpritePrefab(v, translucent:true);
+            _placedPrefabs[v.id] = MakeSpritePrefab(v, translucent:false);
+        }
+        if (_ghostPrefabs.Count == 0)
+        {
+            // synthesize a default visual so we see something
+            var v = new VisualDef { id = "core.Visual.Board_Default", color_rgba = "#F3D95AFF", plane = "XY" };
+            _ghostPrefabs[v.id] = MakeSpritePrefab(v, translucent:true);
+            _placedPrefabs[v.id] = MakeSpritePrefab(v, translucent:false);
+        }
+        Debug.Log($"[SpriteVisualFactory2D] Ready. SortingLayer='{_sortingLayer}', GroundOrder={_orderGround}");
+    }
+
+    public static GameObject SpawnGhost(string visualId, Vector2Int foot, float tile, Transform parent)
+    {
+        if (!_ghostPrefabs.TryGetValue(visualId, out var pf)) return null;
+        var inst = Object.Instantiate(pf, parent);
+        SizeAndPlace(inst.transform, foot, tile, true);
+        return inst;
+    }
+
+    public static GameObject SpawnPlaced(string visualId, Vector2Int foot, float tile, Transform parent)
+    {
+        if (!_placedPrefabs.TryGetValue(visualId, out var pf)) return null;
+        var inst = Object.Instantiate(pf, parent);
+        SizeAndPlace(inst.transform, foot, tile, false);
+        return inst;
+    }
+
+    private static GameObject MakeSpritePrefab(VisualDef vdef, bool translucent)
+    {
+        var go = new GameObject(vdef.id + (translucent?".Ghost":".Placed"));
+        var sr = go.AddComponent<SpriteRenderer>();
+        sr.sprite = _white;
+        sr.sortingLayerName = _sortingLayer;
+        sr.sortingOrder = _orderGround + (translucent?5:3);
+        var c = vdef.Color; if (translucent) c.a *= 0.4f; sr.color = c;
+        go.transform.localPosition = Vector3.zero;
+        go.transform.localRotation = Quaternion.identity; // XY plane
+        return go;
+    }
+
+    private static void SizeAndPlace(Transform t, Vector2Int foot, float tile, bool ghost)
+    {
+        // Scale sprite in XY to desired world size: default white is 1 unit per side already
+        t.localScale = new Vector3(Mathf.Max(0.1f, foot.x * tile), Mathf.Max(0.1f, foot.y * tile), 1f);
+        // offset half size from parent (which is bottom-left)
+        t.localPosition = new Vector3((foot.x * tile) * 0.5f, (foot.y * tile) * 0.5f, ghost ? -0.01f : 0f);
+    }
+
+    private static void EnsureWhiteSprite()
+    {
+        if (_white != null) return;
+        var tex = new Texture2D(1,1, TextureFormat.RGBA32, false);
+        tex.SetPixel(0,0,Color.white); tex.Apply();
+        _white = Sprite.Create(tex, new Rect(0,0,1,1), new Vector2(0.5f,0.5f), 1f);
+    }
+
+    private static void DetectSortingLayer()
+    {
+        // Try to inherit the ground/pawn sorting layer; fallback to Default
+        _sortingLayer = "Default";
+        _orderGround = 0;
+        var anySR = Object.FindAnyObjectByType<SpriteRenderer>();
+        if (anySR != null)
+        {
+            _sortingLayer = anySR.sortingLayerName;
+            _orderGround = anySR.sortingOrder;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SpriteVisualFactory2D` to create simple sprite-based ghost/placed visuals and auto-detect sorting
- bootstrap build systems automatically on scene load and build sprite visuals
- update `BuildPlacementTool` to use sprite ghosts/markers, adjust marker placement, and display mouse coordinates in overlay

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b22a2e14488324b25bc4cfb9c336c4