### PR TITLE
Remove unused marker renderer field

### DIFF
--- a/Assets/Scripts/Build/BuildPlacementTool.cs
+++ b/Assets/Scripts/Build/BuildPlacementTool.cs
@@ -16,7 +16,6 @@ public class BuildPlacementTool : MonoBehaviour
     private GameObject _ghost;
     private MeshRenderer _ghostMr;
     private GameObject _marker;
-    private MeshRenderer _markerMr;
     private bool _canPlace;
     private Vector3 _snapWorldPos;
     private Vector2Int _snapGridPos;
@@ -331,7 +330,6 @@ public class BuildPlacementTool : MonoBehaviour
         _marker = SpriteVisualFactory2D.SpawnGhost(vdef.id, Vector2Int.one, _tile*0.2f, this.transform);
         var sr = _marker.GetComponent<SpriteRenderer>();
         if (sr != null) sr.color = new Color(1f,1f,0.2f,0.85f);
-        _markerMr = null;
     }
 
     private Transform EnsureBuildingsParent()
@@ -515,7 +513,6 @@ public class BuildPlacementTool : MonoBehaviour
         {
             Destroy(_marker);
             _marker = null;
-            _markerMr = null;
         }
     }
 


### PR DESCRIPTION
## Summary
- Drop leftover `_markerMr` MeshRenderer field
- Remove assignments to deleted `_markerMr` in EnsureMarker and DestroyMarker

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d9ffd04832499cc7f24d9edd3a2