### PR TITLE
Hotfix: add VisualDef shim, placeholder Defs.cs, and allow <VisualDef> in XML loader

### DIFF
--- a/Assets/Scripts/Defs/Defs.cs
+++ b/Assets/Scripts/Defs/Defs.cs
@@ -1,0 +1,7 @@
+// Placeholder file to satisfy an existing .meta (Unity asset GUID).
+// Safe to remove later **from inside Unity** along with this file's .meta.
+namespace FantasyColony.Defs
+{
+    internal static class __DefsPlaceholder { }
+}
+

--- a/Assets/Scripts/Defs/VisualDef.cs
+++ b/Assets/Scripts/Defs/VisualDef.cs
@@ -1,0 +1,14 @@
+using FantasyColony.Defs;
+
+/// <summary>
+/// Compatibility shim: legacy code references VisualDef. We now use Visual2DDef.
+/// This shim keeps existing code compiling while we migrate call sites.
+/// </summary>
+[System.Serializable]
+public class VisualDef : Visual2DDef
+{
+    // Intentionally empty. Inherits all fields from Visual2DDef.
+}
+
+
+

--- a/Assets/Scripts/Defs/Xml/XmlDefLoader.cs
+++ b/Assets/Scripts/Defs/Xml/XmlDefLoader.cs
@@ -34,6 +34,12 @@ namespace FantasyColony.Defs.Xml
                                 v.modId = modId;
                                 visuals.Add(v);
                                 break;
+                            // Back-compat: allow <VisualDef> as an alias for <Visual2DDef>
+                            case "VisualDef":
+                                var v2 = ParseVisual2D(root);
+                                v2.modId = modId;
+                                visuals.Add(v2);
+                                break;
                             case BuildingDefKinds.Root:
                                 var b = ParseBuilding(root);
                                 b.modId = modId;


### PR DESCRIPTION
## Summary
- add empty VisualDef class inheriting from Visual2DDef for legacy compatibility
- add Defs.cs placeholder for existing Unity .meta file
- XmlDefLoader now also accepts `<VisualDef>` as an alias for `<Visual2DDef>`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b24098329883248b5d71b8781a87d9