### PR TITLE
Expand defs schema with orientation, pathing, and legacy helpers

### DIFF
--- a/Assets/Scripts/Defs/BuildingDef.cs
+++ b/Assets/Scripts/Defs/BuildingDef.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace FantasyColony.Defs
 {
@@ -8,11 +9,46 @@ namespace FantasyColony.Defs
     [Serializable]
     public class BuildingDef : Def
     {
+        // Identity & UI
+        public string label;
+        public string description;
+        public string category;
+        public bool showInPalette = true;
+        public bool unique = false;
+
+        // Footprint & orientation
         public int width = 1;
         public int height = 1;
-        public bool unique = false;
-        public bool showInPalette = true;
+        /// <summary>Allowed headings, e.g., ["N","E","S","W"]. If null/empty, assume all four.</summary>
+        public List<string> allowedRotations;
+        public string defaultRotation = "N";
+
+        // Placement rules
+        /// <summary>Preferred plane for placement/preview; falls back to visual's plane if empty.</summary>
+        public string plane;
+
+        // Pathing
+        /// <summary>If true, navgrid can pass through this footprint.</summary>
+        public bool canPathThrough = false;
+        /// <summary>Soft avoidance radius (in tiles) to discourage pathing too close unless interacting.</summary>
+        public float avoidanceRadius = 0f;
+
+        // Interactions
+        public List<string> interactTags;
+
+        // Cost & work (v1: work only)
+        public float workToBuild = 0f;
+
+        // Visual link
         public string visualRef; // defName of a Visual2DDef
+
+        // --- Compatibility aliases (temporary during migration) ---
+        // Old snake_case alias; maps to visualRef.
+        public string visual_ref
+        {
+            get => visualRef;
+            set => visualRef = value;
+        }
     }
 }
 

--- a/Assets/Scripts/Defs/DefDatabase.cs
+++ b/Assets/Scripts/Defs/DefDatabase.cs
@@ -8,26 +8,52 @@ namespace FantasyColony.Defs
     /// </summary>
     public static class DefDatabase
     {
-        private static readonly List<Visual2DDef> _visuals = new List<Visual2DDef>();
-        private static readonly List<BuildingDef> _buildings = new List<BuildingDef>();
+        // Primary stores keyed by defName for fast lookup
+        private static readonly Dictionary<string, Visual2DDef> _visualsByName = new Dictionary<string, Visual2DDef>();
+        private static readonly Dictionary<string, BuildingDef> _buildingsByName = new Dictionary<string, BuildingDef>();
 
-        public static IReadOnlyList<Visual2DDef> Visuals => _visuals;
-        public static IReadOnlyList<BuildingDef> Buildings => _buildings;
+        // Legacy-style lists (for simple iteration) - derived views
+        private static readonly List<Visual2DDef> _visualsList = new List<Visual2DDef>();
+        private static readonly List<BuildingDef> _buildingsList = new List<BuildingDef>();
 
-        public static int TotalCount => _visuals.Count + _buildings.Count;
+        public static IReadOnlyDictionary<string, Visual2DDef> VisualsByName => _visualsByName;
+        public static IReadOnlyDictionary<string, BuildingDef> BuildingsByName => _buildingsByName;
+
+        public static IReadOnlyList<Visual2DDef> Visuals => _visualsList;
+        public static IReadOnlyList<BuildingDef> Buildings => _buildingsList;
+
+        public static int TotalCount => _visualsByName.Count + _buildingsByName.Count;
 
         /// <summary>
         /// Called from BuildBootstrap.Ensure() during startup.
         /// </summary>
         public static void LoadAll()
         {
-            _visuals.Clear();
-            _buildings.Clear();
+            _visualsByName.Clear();
+            _buildingsByName.Clear();
+            _visualsList.Clear();
+            _buildingsList.Clear();
 
             try
             {
-                Xml.XmlDefLoader.LoadAll(_visuals, _buildings);
-                Debug.Log($"[Defs] Loaded {TotalCount} defs (visuals: {_visuals.Count}, buildings: {_buildings.Count}).");
+                var visualsTmp = new List<Visual2DDef>();
+                var buildingsTmp = new List<BuildingDef>();
+                Xml.XmlDefLoader.LoadAll(visualsTmp, buildingsTmp);
+
+                foreach (var v in visualsTmp)
+                {
+                    if (string.IsNullOrEmpty(v.defName)) continue;
+                    _visualsByName[v.defName] = v;
+                }
+                foreach (var b in buildingsTmp)
+                {
+                    if (string.IsNullOrEmpty(b.defName)) continue;
+                    _buildingsByName[b.defName] = b;
+                }
+                _visualsList.AddRange(_visualsByName.Values);
+                _buildingsList.AddRange(_buildingsByName.Values);
+
+                Debug.Log($"[Defs] Loaded {TotalCount} defs (visuals: {_visualsByName.Count}, buildings: {_buildingsByName.Count}).");
             }
             catch (System.Exception ex)
             {
@@ -35,5 +61,29 @@ namespace FantasyColony.Defs
             }
         }
     }
-}
 
+    /// <summary>Small helpers to keep legacy call sites compiling during migration.</summary>
+    public static class DefListExtensions
+    {
+        public static bool TryGetValue(this IReadOnlyList<Visual2DDef> list, string defName, out Visual2DDef def)
+        {
+            def = null;
+            if (string.IsNullOrEmpty(defName)) return false;
+            foreach (var v in list)
+            {
+                if (v != null && v.defName == defName) { def = v; return true; }
+            }
+            return false;
+        }
+        public static bool TryGetValue(this IReadOnlyList<BuildingDef> list, string defName, out BuildingDef def)
+        {
+            def = null;
+            if (string.IsNullOrEmpty(defName)) return false;
+            foreach (var b in list)
+            {
+                if (b != null && b.defName == defName) { def = b; return true; }
+            }
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Defs/Visual2DDef.cs
+++ b/Assets/Scripts/Defs/Visual2DDef.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace FantasyColony.Defs
 {
@@ -13,6 +14,26 @@ namespace FantasyColony.Defs
         public int sortingOrder = 0;
         public float pivotX = 0.5f;
         public float pivotY = 0.0f;
+        public float scale = 1.0f;
+
+        // Plane & depth
+        public string plane = "XY"; // XY or XZ
+        public float z_lift = 0f;   // legacy-friendly name kept
+
+        // Material & color (kept for legacy VisualFactory code)
+        public string shader_hint;         // optional material/shader hint
+        public string color_rgba = "1,1,1,1";
+
+        // Optional variant sprites
+        public List<Variant> variants;
+
+        [Serializable]
+        public class Variant
+        {
+            public string spritePath;
+            public int weight = 1;
+            public string conditionTag;
+        }
     }
 }
 

--- a/Assets/Scripts/Defs/VisualDef.cs
+++ b/Assets/Scripts/Defs/VisualDef.cs
@@ -1,4 +1,5 @@
 using FantasyColony.Defs;
+using UnityEngine;
 
 /// <summary>
 /// Compatibility shim: legacy code references VisualDef. We now use Visual2DDef.
@@ -7,8 +8,70 @@ using FantasyColony.Defs;
 [System.Serializable]
 public class VisualDef : Visual2DDef
 {
-    // Intentionally empty. Inherits all fields from Visual2DDef.
+    // Intentionally mostly empty; below are legacy helper keys & parsers expected by old code.
+    // --- Legacy static keys (string) ---
+    public static readonly string id = nameof(defName);
+    public static readonly string render_layer = nameof(sortingLayer);
+    public static readonly string color_rgba_key = "color_rgba"; // avoid name clash
+    public static readonly string plane_key = "plane";
+    public static readonly string shader_hint_key = "shader_hint";
+    public static readonly string z_lift_key = "z_lift";
+
+    // Legacy helper methods (parsers)
+    public static Color Color(Visual2DDef def, string key, Color fallback)
+    {
+        var src = (def as VisualDef)?.color_rgba ?? def.color_rgba;
+        if (string.IsNullOrEmpty(src)) return fallback;
+        var parts = src.Split(',');
+        if (parts.Length < 3) return fallback;
+        float r = Parse(parts[0], 1f), g = Parse(parts[1], 1f), b = Parse(parts[2], 1f);
+        float a = parts.Length > 3 ? Parse(parts[3], 1f) : 1f;
+        return new Color(r, g, b, a);
+    }
+    public static int Plane(Visual2DDef def, string key, int fallback)
+    {
+        var p = (def as VisualDef)?.plane ?? def.plane ?? "XY";
+        return p.Equals("XZ", System.StringComparison.OrdinalIgnoreCase) ? 1 : 0;
+    }
+    public static string Plane(Visual2DDef def, string key, string fallback)
+    {
+        var p = (def as VisualDef)?.plane ?? def.plane;
+        return string.IsNullOrEmpty(p) ? fallback : p;
+    }
+    private static float Parse(string s, float d)
+    {
+        return float.TryParse(s, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : d;
+    }
 }
-
-
-
+/// <summary>Legacy "Value" access pattern used by rendering code: allow key-based lookups from Visual2DDef.</summary>
+public static class VisualDefExtensions
+{
+    public static string Value(this Visual2DDef d, string key, string fallback = null)
+    {
+        switch (key)
+        {
+            case "id": return d.defName ?? fallback;
+            case "render_layer": return d.sortingLayer ?? fallback;
+            case "plane": return d.plane ?? fallback;
+            case "shader_hint": return (d as VisualDef)?.shader_hint ?? d.shader_hint ?? fallback;
+            case "color_rgba": return (d as VisualDef)?.color_rgba ?? d.color_rgba ?? fallback;
+            default: return fallback;
+        }
+    }
+    public static int Value(this Visual2DDef d, string key, int fallback)
+    {
+        switch (key)
+        {
+            case "sortingOrder": return d.sortingOrder;
+            default: return fallback;
+        }
+    }
+    public static float Value(this Visual2DDef d, string key, float fallback)
+    {
+        switch (key)
+        {
+            case "z_lift": return d.z_lift;
+            default: return fallback;
+        }
+    }
+}

--- a/Assets/Scripts/Defs/Xml/XmlDefLoader.cs
+++ b/Assets/Scripts/Defs/Xml/XmlDefLoader.cs
@@ -78,24 +78,89 @@ namespace FantasyColony.Defs.Xml
         private static Visual2DDef ParseVisual2D(XElement root)
         {
             var v = new Visual2DDef();
-            v.defName = Value(root, nameof(Visual2DDef.defName), required: true);
-            v.spritePath = Value(root, nameof(Visual2DDef.spritePath), required: true);
-            v.sortingLayer = Value(root, nameof(Visual2DDef.sortingLayer), defaultValue: "Default");
-            v.sortingOrder = Int(root, nameof(Visual2DDef.sortingOrder), 0);
-            v.pivotX = Float(root, nameof(Visual2DDef.pivotX), 0.5f);
-            v.pivotY = Float(root, nameof(Visual2DDef.pivotY), 0.0f);
+            v.defName      = Value(root, "defName", required: true);
+            v.spritePath   = Value(root, "spritePath", required: true);
+
+            // Sorting & transform
+            v.sortingLayer = Value(root, "sortingLayer", defaultValue: "Default");
+            v.sortingOrder = Int(root, "sortingOrder", 0);
+            v.pivotX       = Float(root, "pivotX", 0.5f);
+            v.pivotY       = Float(root, "pivotY", 0.0f);
+            v.scale        = Float(root, "scale", 1.0f);
+
+            // Plane & depth
+            v.plane        = Value(root, "plane", defaultValue: "XY");
+            v.z_lift       = Float(root, "z_lift", 0f);
+
+            // Material & color
+            v.shader_hint  = Value(root, "shader_hint", defaultValue: null);
+            v.color_rgba   = Value(root, "color_rgba", defaultValue: "1,1,1,1");
+
+            // Variants
+            var variantsEl = root.Element("variants");
+            if (variantsEl != null)
+            {
+                v.variants = new List<Visual2DDef.Variant>();
+                foreach (var li in variantsEl.Elements("li"))
+                {
+                    var varEl = new Visual2DDef.Variant
+                    {
+                        spritePath   = li.Element("spritePath")?.Value?.Trim(),
+                        weight       = Int(li, "weight", 1),
+                        conditionTag = li.Element("conditionTag")?.Value?.Trim()
+                    };
+                    if (!string.IsNullOrEmpty(varEl.spritePath))
+                        v.variants.Add(varEl);
+                }
+            }
             return v;
         }
 
         private static BuildingDef ParseBuilding(XElement root)
         {
             var b = new BuildingDef();
-            b.defName = Value(root, nameof(BuildingDef.defName), required: true);
-            b.width = Int(root, nameof(BuildingDef.width), 1);
-            b.height = Int(root, nameof(BuildingDef.height), 1);
-            b.unique = Bool(root, nameof(BuildingDef.unique), false);
-            b.showInPalette = Bool(root, nameof(BuildingDef.showInPalette), true);
-            b.visualRef = Value(root, nameof(BuildingDef.visualRef), required: false);
+            // Identity & UI
+            b.defName       = Value(root, "defName", required: true);
+            b.label         = Value(root, "label", defaultValue: null);
+            b.description   = Value(root, "description", defaultValue: null);
+            b.category      = Value(root, "category", defaultValue: null);
+            b.showInPalette = Bool(root, "showInPalette", true);
+            b.unique        = Bool(root, "unique", false);
+
+            // Footprint & orientation
+            b.width            = Int(root, "width", 1);
+            b.height           = Int(root, "height", 1);
+            var ar = Value(root, "allowedRotations", defaultValue: null);
+            if (!string.IsNullOrEmpty(ar))
+                b.allowedRotations = new List<string>(ar.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries));
+            b.defaultRotation  = Value(root, "defaultRotation", defaultValue: "N");
+
+            // Placement rules
+            b.plane = Value(root, "plane", defaultValue: null);
+
+            // Pathing
+            b.canPathThrough  = Bool(root, "canPathThrough", false);
+            b.avoidanceRadius = Float(root, "avoidanceRadius", 0f);
+
+            // Interactions
+            var tagsEl = root.Element("interactTags");
+            if (tagsEl != null)
+            {
+                b.interactTags = new List<string>();
+                foreach (var li in tagsEl.Elements("li"))
+                {
+                    var t = li.Value?.Trim();
+                    if (!string.IsNullOrEmpty(t)) b.interactTags.Add(t);
+                }
+            }
+
+            // Costs/work
+            b.workToBuild = Float(root, "workToBuild", 0f);
+
+            // Visual link (camelCase and snake_case)
+            b.visualRef = Value(root, "visualRef", defaultValue: null);
+            if (string.IsNullOrEmpty(b.visualRef))
+                b.visualRef = Value(root, "visual_ref", defaultValue: null);
             return b;
         }
 

--- a/Assets/StreamingAssets/Mods/Core/Defs/Buildings/ConstructionBoard.xml
+++ b/Assets/StreamingAssets/Mods/Core/Defs/Buildings/ConstructionBoard.xml
@@ -1,9 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <BuildingDef>
+  <!-- Identity & UI -->
   <defName>ConstructionBoard</defName>
+  <label>Construction Board</label>
+  <description>A planning station for future construction.</description>
+  <category>Stations</category>
+  <showInPalette>true</showInPalette>
+  <unique>true</unique>
+
+  <!-- Footprint & orientation -->
   <width>3</width>
   <height>1</height>
-  <unique>true</unique>
-  <showInPalette>true</showInPalette>
+  <allowedRotations>N,E,S,W</allowedRotations>
+  <defaultRotation>N</defaultRotation>
+
+  <!-- Placement rules -->
+  <plane>XY</plane>
+
+  <!-- Pathing -->
+  <canPathThrough>false</canPathThrough>
+  <avoidanceRadius>0.35</avoidanceRadius>
+
+  <!-- Interactions -->
+  <interactTags>
+    <li>construction</li>
+    <li>board</li>
+  </interactTags>
+
+  <!-- Work only (no materials in v1) -->
+  <workToBuild>2.0</workToBuild>
+
+  <!-- Visual reference -->
   <visualRef>ConstructionBoardVisual</visualRef>
+  <!-- TEMP legacy alias during migration -->
+  <visual_ref>ConstructionBoardVisual</visual_ref>
 </BuildingDef>

--- a/Assets/StreamingAssets/Mods/Core/Defs/Visuals/ConstructionBoardVisual.xml
+++ b/Assets/StreamingAssets/Mods/Core/Defs/Visuals/ConstructionBoardVisual.xml
@@ -6,4 +6,9 @@
   <sortingOrder>0</sortingOrder>
   <pivotX>0.5</pivotX>
   <pivotY>0.0</pivotY>
+  <scale>1.0</scale>
+  <plane>XY</plane>
+  <z_lift>0</z_lift>
+  <shader_hint>Sprites/Default</shader_hint>
+  <color_rgba>1,1,1,1</color_rgba>
 </Visual2DDef>


### PR DESCRIPTION
## Summary
- flesh out BuildingDef with orientation, pathing, and interaction metadata
- migrate DefDatabase to keyed dictionaries and provide legacy TryGetValue helpers
- extend Visual2DDef plus XML loader and sample defs for schema v1

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2484d408c83249af8927ff80a744c