### PR TITLE
Improve visual registry for list-based DefDatabase and placeholders

### DIFF
--- a/Assets/Scripts/Rendering/SpriteVisualFactory2D.cs
+++ b/Assets/Scripts/Rendering/SpriteVisualFactory2D.cs
@@ -20,11 +20,24 @@ public static class SpriteVisualFactory2D
         EnsureWhiteSprite();
         DetectSortingLayer();
 
-        foreach (var kv in DefDatabase.Visuals)
+        foreach (var v in DefDatabase.Visuals)
         {
-            var v = kv.Value;
-            _ghostPrefabs[v.id] = MakeSpritePrefab(v, translucent:true);
-            _placedPrefabs[v.id] = MakeSpritePrefab(v, translucent:false);
+            // DefDatabase.Visuals is a list; build prefabs keyed by defName
+            var vd = v as VisualDef ?? new VisualDef
+            {
+                defName = v.defName,
+                sortingLayer = v.sortingLayer,
+                sortingOrder = v.sortingOrder,
+                pivotX = v.pivotX,
+                pivotY = v.pivotY,
+                scale = v.scale,
+                plane = v.plane,
+                z_lift = v.z_lift,
+                shader_hint = v.shader_hint,
+                color_rgba = v.color_rgba
+            };
+            _ghostPrefabs[vd.id] = MakeSpritePrefab(vd, translucent: true);
+            _placedPrefabs[vd.id] = MakeSpritePrefab(vd, translucent: false);
         }
         if (_ghostPrefabs.Count == 0)
         {


### PR DESCRIPTION
## Summary
- add instance properties and color/plane parsers to `VisualDef`
- adapt sprite factory and visual registry to build from DefDatabase lists
- support spawning visual prefabs without external art assets

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b24d937e088324a66c516a59231839