### PR TITLE
Fix NETSDK1022 by removing explicit <Compile> includes

### DIFF
--- a/Tools/XmlDefsTools/XmlDefsTools.csproj
+++ b/Tools/XmlDefsTools/XmlDefsTools.csproj
@@ -8,14 +8,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="Scan\XmlDefScanner.cs" />
-    <Compile Include="Emit\XmlIndexWriter.cs" />
-    <Compile Include="Emit\XmlSnapshotWriter.cs" />
-    <Compile Include="Emit\TemplateSynthesizer.cs" />
-    <Compile Include="Util\CanonicalXml.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Config\SchemaOrder.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary
- fix NETSDK1022 by relying on SDK implicit compile items instead of explicit `<Compile>` entries in `XmlDefsTools.csproj`

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68b252a86144832496fe3f8f28bdad54