### PR TITLE
Fix canonical attribute ordering and element detection

### DIFF
--- a/Tools/XmlDefsTools/Emit/TemplateSynthesizer.cs
+++ b/Tools/XmlDefsTools/Emit/TemplateSynthesizer.cs
@@ -37,6 +37,8 @@ namespace XmlDefsTools.Emit
                 // Remaining element fields
                 var elementNames = NormalizeOrder(elemFields, precedence);
 
+                bool HasElem(string name) => elementNames.Any(n => n.Equals(name, StringComparison.OrdinalIgnoreCase));
+
                 var sb = new StringBuilder();
                 sb.AppendLine($"<!-- Auto-generated default template for {schema}. Edit your copies; this file is regenerated. -->");
 
@@ -53,13 +55,13 @@ namespace XmlDefsTools.Emit
                 }
 
                 // Insert version/requires as elements too if heavily used as elements
-                if (elementNames.Contains("version", StringComparer.OrdinalIgnoreCase) && root.Attribute("version") == null)
+                if (HasElem("version") && root.Attribute("version") == null)
                     root.Add(new XElement("version", "1"));
-                if (elementNames.Contains("requires", StringComparer.OrdinalIgnoreCase) && root.Attribute("requires") == null)
+                if (HasElem("requires") && root.Attribute("requires") == null)
                     root.Add(new XElement("requires"));
 
                 // Components block if observed
-                if (elementNames.Contains("components", StringComparer.OrdinalIgnoreCase))
+                if (HasElem("components"))
                 {
                     root.Add(new XElement("components",
                         new XComment(" Add component entries like <Component type=\"...\"/> ")));

--- a/Tools/XmlDefsTools/Util/CanonicalXml.cs
+++ b/Tools/XmlDefsTools/Util/CanonicalXml.cs
@@ -43,7 +43,7 @@ namespace XmlDefsTools.Util
         {
             var orderedAttrs = el.Attributes()
                 .Where(a => !a.IsNamespaceDeclaration)
-                .OrderBy(a => OrderKey(a.Name.LocalName), StringComparer.OrdinalIgnoreCase)
+                .OrderBy(a => OrderKey(a.Name.LocalName))
                 .ThenBy(a => a.Name.LocalName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 


### PR DESCRIPTION
## Summary
- Ensure element membership checks in template synthesis are case-insensitive
- Use default comparer when ordering attributes by precedence to satisfy CI build

## Testing
- `dotnet build Tools/XmlDefsTools -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b253db3a008324a3c9bd1919bfd934