### PR TITLE
Fix JSON: remove stray comment key in SchemaOrder

### DIFF
--- a/Tools/XmlDefsTools/Config/SchemaOrder.json
+++ b/Tools/XmlDefsTools/Config/SchemaOrder.json
@@ -7,7 +7,6 @@
     "version",
     "requires"
   ],
-  "//": "Seed known schemas so we always emit a baseline template even before any defs exist.",
   "BuildingDef": [
     "id", "name_key", "tags", "version", "requires",
     "icon", "size", "cost", "hitPoints", "components"


### PR DESCRIPTION
## Summary
- remove `"//"` comment key from SchemaOrder.json to keep JSON valid

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b259e21e7c83249d9afa56bf90a5e3