### PR TITLE
Silence SYSLIB0013 warnings for GitHub URL encoding

### DIFF
--- a/Tools/XmlDefsTools/Emit/XmlIndexWriter.cs
+++ b/Tools/XmlDefsTools/Emit/XmlIndexWriter.cs
@@ -54,8 +54,9 @@ namespace XmlDefsTools.Emit
                 {
                     var rel = Rel(repoRoot, file);
                     var webPath = rel.Replace('\\','/'); // ensure URL form
-                    var viewUrl = $"https://github.com/{repo}/blob/{branch}/{Uri.EscapeUriString(webPath)}";
-                    var rawUrl  = $"https://raw.githubusercontent.com/{repo}/{branch}/{Uri.EscapeUriString(webPath)}";
+                    var enc = EncodePathSegments(webPath);
+                    var viewUrl = $"https://github.com/{repo}/blob/{branch}/{enc}";
+                    var rawUrl  = $"https://raw.githubusercontent.com/{repo}/{branch}/{enc}";
                     sb.AppendLine($"- `{webPath}` — [View]({viewUrl}) · [Raw]({rawUrl})");
                 }
                 sb.AppendLine();
@@ -107,6 +108,14 @@ namespace XmlDefsTools.Emit
 
             Directory.CreateDirectory(Path.GetDirectoryName(outFile)!);
             File.WriteAllText(outFile, sb.ToString());
+        }
+
+        // Encode each path segment to avoid corrupting '/' and handle special characters safely.
+        private static string EncodePathSegments(string path)
+        {
+            var parts = path.Replace('\\','/').Split(new[]{'/'}, StringSplitOptions.RemoveEmptyEntries);
+            var encoded = parts.Select(Uri.EscapeDataString);
+            return string.Join("/", encoded);
         }
 
         private static (string repo, string branch) RepoMeta()


### PR DESCRIPTION
## Summary
- avoid using deprecated `Uri.EscapeUriString` when building GitHub URLs
- encode paths segment-wise to preserve slashes and handle special characters

## Testing
- `dotnet build Tools/XmlDefsTools/XmlDefsTools.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b25ae285448324939c2c2d3df46887