### PR TITLE
Fix NETSDK1022 by removing explicit Compile include

### DIFF
--- a/Tools/XmlDefsTools/XmlDefsTools.csproj
+++ b/Tools/XmlDefsTools/XmlDefsTools.csproj
@@ -11,7 +11,6 @@
     <None Include="Config\SchemaOrder.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <Compile Include="Emit\SchemaCatalogWriter.cs" />
   </ItemGroup>
   <PropertyGroup>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>


### PR DESCRIPTION
## Summary
- rely on implicit SDK compile items in XmlDefsTools to avoid NETSDK1022

## Testing
- `dotnet build Tools/XmlDefsTools/XmlDefsTools.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b25d0890648324a44a191bce39fcfa