### PR TITLE
Use hi-res sprites for Construction Board placement

### DIFF
--- a/Assets/Scripts/Build/BuildPaletteHUD.cs
+++ b/Assets/Scripts/Build/BuildPaletteHUD.cs
@@ -7,7 +7,7 @@ using UnityEngine.UIElements;
 public class BuildPaletteHUD : MonoBehaviour
 {
     Vector2 _scroll;
-    Rect _panelRect = new Rect(16, 64, 320, 420);
+    Rect _panelRect = new Rect(16, 64, 480, 540);
 
     void OnGUI()
     {

--- a/Assets/Scripts/Rendering/SpriteVisualFactory2D.cs
+++ b/Assets/Scripts/Rendering/SpriteVisualFactory2D.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using FantasyColony.Defs;
 using UnityEngine;
+using System.Linq;
 
 public static class SpriteVisualFactory2D
 {
@@ -69,7 +70,13 @@ public static class SpriteVisualFactory2D
     {
         var go = new GameObject(vdef.id + (translucent?".Ghost":".Placed"));
         var sr = go.AddComponent<SpriteRenderer>();
-        sr.sprite = _white;
+        Sprite sprite = _white;
+        if (!string.IsNullOrEmpty(vdef.spritePath))
+        {
+            var loaded = Resources.Load<Sprite>(vdef.spritePath);
+            if (loaded != null) sprite = loaded;
+        }
+        sr.sprite = sprite;
         sr.sortingLayerName = _sortingLayer;
         sr.sortingOrder = _orderGround + (translucent?5:3);
         var c = vdef.Color; if (translucent) c.a *= 0.4f; sr.color = c;

--- a/Assets/StreamingAssets/Mods/Core/Defs/Buildings/ConstructionBoard.xml
+++ b/Assets/StreamingAssets/Mods/Core/Defs/Buildings/ConstructionBoard.xml
@@ -6,7 +6,7 @@
     <width>3</width>
     <height>1</height>
     <unique>true</unique>
-    <allowedRotations>N,E,S,W</allowedRotations>
+    <allowedRotations>N</allowedRotations>
     <workToBuild>2.0</workToBuild>
     <interactTags>
       <li>construction</li>


### PR DESCRIPTION
## Summary
- restrict Construction Board to a single rotation
- widen build palette panel
- load sprites from defs for ghost and placed visuals
- allow SpriteVisualFactory2D to use spritePath textures

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b267606e8c8324a8cd3f406b9c2ad2