### PR TITLE
Switch to Visual2DDef in build utilities and factory

### DIFF
--- a/Assets/Scripts/Build/BuildPlacementTool.cs
+++ b/Assets/Scripts/Build/BuildPlacementTool.cs
@@ -68,7 +68,7 @@ public class BuildPlacementTool : MonoBehaviour
         }
     }
 
-    VisualDef GetVisualDefFor(BuildingDef def)
+    Visual2DDef GetVisualDefFor(BuildingDef def)
     {
         if (def == null) return null;
         if (string.IsNullOrEmpty(def.visualRef)) return null;


### PR DESCRIPTION
## Summary
- Fix BuildPlacementTool to query Visual2DDef instead of legacy VisualDef
- Update SpriteVisualFactory2D to work directly with Visual2DDef, including default fallback and color parsing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b26885192883249993bd67c2889bfa