### PR TITLE
Auto-spawn Build HUD and self-healing build tools

### DIFF
--- a/Assets/Scripts/Boot/BuildBootstrap.cs
+++ b/Assets/Scripts/Boot/BuildBootstrap.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using FantasyColony.Defs;
+using System.Linq;
 
 /// <summary>
 /// Guarantees build systems exist at runtime and that defs are loaded.
@@ -13,7 +14,7 @@ public static class BuildBootstrap
         Ensure();
     }
 
-    public static void Ensure()
+    public static GameObject Ensure()
     {
         var go = GameObject.Find("BuildSystems (Auto)");
         if (go == null)
@@ -39,6 +40,18 @@ public static class BuildBootstrap
         {
             // ignore – bring-up should still run with fallbacks
         }
+
+        // Ensure there is a HUD
+        var hud = GameObject.Find("BuildHUD (Auto)");
+        if (hud == null)
+        {
+            hud = new GameObject("BuildHUD (Auto)");
+            hud.AddComponent<BuildHUD>();
+            hud.AddComponent<BuildPaletteHUD>();
+            Debug.Log("[BuildBootstrap] Spawned BuildHUD + Palette");
+        }
+
+        return go;
     }
 }
 

--- a/Assets/Scripts/Build/BuildHUD.cs
+++ b/Assets/Scripts/Build/BuildHUD.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+/// <summary>
+/// Minimal header HUD that exposes a Build toggle and self-heals missing systems.
+/// </summary>
+public class BuildHUD : MonoBehaviour
+{
+    BuildModeController Ctrl => BuildModeController.Instance;
+
+    Rect HeaderRect => new Rect(12, 12, 160, 32);
+
+    void OnGUI()
+    {
+        var ctrl = Ctrl;
+        if (ctrl == null)
+        {
+            BuildBootstrap.Ensure();
+            ctrl = BuildModeController.Instance;
+        }
+        GUILayout.BeginArea(HeaderRect, GUI.skin.window);
+        GUILayout.BeginHorizontal();
+        GUILayout.Label(ctrl != null && ctrl.IsActive ? "●" : "○", GUILayout.Width(20));
+        if (GUILayout.Button("Build [B]", GUILayout.Height(20)))
+        {
+            if (ctrl != null) ctrl.ToggleBuildMode();
+        }
+        GUILayout.EndHorizontal();
+        GUILayout.EndArea();
+    }
+}
+

--- a/Assets/Scripts/Build/BuildModeController.cs
+++ b/Assets/Scripts/Build/BuildModeController.cs
@@ -19,7 +19,15 @@ public class BuildModeController : MonoBehaviour
 
     private void Awake()
     {
-        Instance = this;
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else if (Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
     }
 
     public bool IsBuildModeEnabled => _buildModeEnabled;
@@ -79,6 +87,7 @@ public class BuildModeController : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.B))
         {
             ToggleBuildMode();
+            Debug.Log("[Build] Toggled via B → " + (_buildModeEnabled ? "ON" : "OFF"));
         }
         // ESC cancels current tool
         if (Input.GetKeyDown(KeyCode.Escape))

--- a/Assets/Scripts/Build/BuildPaletteHUD.cs
+++ b/Assets/Scripts/Build/BuildPaletteHUD.cs
@@ -21,7 +21,7 @@ public class BuildPaletteHUD : MonoBehaviour
     {
         if (BuildModeController.Instance == null || !BuildModeController.Instance.IsActive) return;
 
-        // Ensure systems exist (harmless if already present)
+        // Self-heal to guarantee systems are present
         BuildBootstrap.Ensure();
 
         var _panelRect = GetPanelRect();

--- a/Assets/Scripts/Build/BuildPlacementTool.cs
+++ b/Assets/Scripts/Build/BuildPlacementTool.cs
@@ -107,8 +107,8 @@ public class BuildPlacementTool : MonoBehaviour
     {
         var scale = ComputeScaleForSprite(spriteOrNull, def);
         go.transform.localScale = scale;
-        // Lay the sprite flat on XZ ground (face +Y)
-        go.transform.rotation = Quaternion.Euler(90f, 0f, 0f);
+        // Lay the sprite flat on XZ ground (face camera looking down -Y)
+        go.transform.rotation = Quaternion.Euler(-90f, 0f, 0f);
         // keep y slightly above ground to avoid z-fighting
     }
 


### PR DESCRIPTION
## Summary
- Ensure BuildBootstrap returns created build systems and spawns a minimal HUD with palette on demand
- Add lightweight BuildHUD for toggling build mode and auto-healing missing systems
- Harden BuildModeController singleton and log keyboard toggles; adjust placement rotation
- Build palette self-heals and placement tool sprite orientation fixed

## Testing
- ⚠️ `dotnet build Tools/XmlDefsTools/XmlDefsTools.csproj` (command not found: dotnet)
- ⚠️ `apt-get update` (repositories not signed, 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68b26fdb32a08324b795940ebbe8aebb