### PR TITLE
Improve build system persistence and placement interactions

### DIFF
--- a/Assets/Scripts/Boot/BuildBootstrap.cs
+++ b/Assets/Scripts/Boot/BuildBootstrap.cs
@@ -20,6 +20,7 @@ public static class BuildBootstrap
         if (go == null)
         {
             go = new GameObject("BuildSystems (Auto)");
+            Object.DontDestroyOnLoad(go);
         }
 
         if (go.GetComponent<BuildModeController>() == null)
@@ -48,6 +49,7 @@ public static class BuildBootstrap
             hud = new GameObject("BuildHUD (Auto)");
             hud.AddComponent<BuildHUD>();
             hud.AddComponent<BuildPaletteHUD>();
+            Object.DontDestroyOnLoad(hud);
             Debug.Log("[BuildBootstrap] Spawned BuildHUD + Palette");
         }
 

--- a/Assets/Scripts/Build/BuildHUD.cs
+++ b/Assets/Scripts/Build/BuildHUD.cs
@@ -11,6 +11,13 @@ public class BuildHUD : MonoBehaviour
 
     void OnGUI()
     {
+        // Hide on intro/title screens if an IntroScreen surface exists and is visible.
+        try
+        {
+            var intro = FindAnyObjectByType<IntroScreen>();
+            if (intro != null && intro.isActiveAndEnabled) return;
+        } catch { /* safe if class not present */ }
+
         var ctrl = Ctrl;
         if (ctrl == null)
         {

--- a/Assets/Scripts/Build/BuildPaletteHUD.cs
+++ b/Assets/Scripts/Build/BuildPaletteHUD.cs
@@ -11,9 +11,9 @@ public class BuildPaletteHUD : MonoBehaviour
 
     Rect GetPanelRect()
     {
-        // Responsive panel sizing for high-DPI / large resolutions
-        float w = Mathf.Clamp(Screen.width * 0.28f, 420f, 760f);
-        float h = Mathf.Clamp(Screen.height * 0.62f, 540f, 980f);
+        // More aggressive sizing for high-DPI / large resolutions
+        float w = Mathf.Max(520f, Screen.width * 0.38f);
+        float h = Mathf.Max(600f, Screen.height * 0.72f);
         return new Rect(16, 64, w, h);
     }
 
@@ -29,6 +29,7 @@ public class BuildPaletteHUD : MonoBehaviour
         GUILayout.BeginArea(_panelRect, GUI.skin.window);
         var activeName = (Ctrl.SelectedBuildingDef != null) ? $" – Selected: {Ctrl.SelectedBuildingDef.label ?? Ctrl.SelectedBuildingDef.defName}" : "";
         GUILayout.Label("Build Palette" + activeName);
+        GUILayout.Label("Click a def to arm the tool, then left-click ground to place. Esc cancels.");
 
         // Try to enumerate building defs (fallback to a single Construction Board def if database not ready)
         var defs = GetPaletteDefs();
@@ -36,8 +37,8 @@ public class BuildPaletteHUD : MonoBehaviour
         foreach (var def in defs)
         {
             GUILayout.BeginHorizontal();
-            GUILayout.Label(def.label ?? def.defName, GUILayout.Width(200));
-            if (GUILayout.Button("Select", GUILayout.Width(80)))
+            GUILayout.Label(def.label ?? def.defName, GUILayout.Width(240));
+            if (GUILayout.Button("Select", GUILayout.Width(140)))
             {
                 // For now we only have a placement tool for Construction Board.
                 // Down the road this can dispatch different tools per def.category/type.

--- a/Assets/Scripts/Build/BuildPlacementTool.cs
+++ b/Assets/Scripts/Build/BuildPlacementTool.cs
@@ -25,6 +25,8 @@ public class BuildPlacementTool : MonoBehaviour
     BuildTool active = BuildTool.None;
 
     readonly Plane groundPlane = new Plane(Vector3.up, 0f); // XZ ground at y=0
+    // Prevent click-through after arming tool from a UI button press
+    bool suppressClickUntilMouseUp = false;
 
     void Start()
     {
@@ -38,7 +40,13 @@ public class BuildPlacementTool : MonoBehaviour
         EnsureGhostDestroyed();
         if (active == BuildTool.PlaceConstructionBoard && ctrl.SelectedBuildingDef != null)
         {
+            suppressClickUntilMouseUp = true; // wait for left mouse to be released once
             EnsureGhost(ctrl.SelectedBuildingDef);
+            // Position ghost immediately under cursor (no first-frame origin flicker)
+            if (cam == null) cam = Camera.main;
+            if (TryGetCursorHit(out var hit))
+                ghostGO.transform.position = SnapToGridXZ(hit, ctrl.SelectedBuildingDef) + new Vector3(0f, 0.02f, 0f);
+            Debug.Log("[Build] Tool armed for " + (ctrl.SelectedBuildingDef.defName ?? "Unknown"));
         }
     }
 
@@ -55,19 +63,21 @@ public class BuildPlacementTool : MonoBehaviour
         }
 
         // Move ghost to snapped mouse position
-        var ray = cam.ScreenPointToRay(Input.mousePosition);
-        Vector3 hit;
-        if (!groundPlane.Raycast(ray, out var enter))
+        if (!TryGetCursorHit(out var hit))
             return;
-        hit = ray.GetPoint(enter); // y == 0 plane
         var snapped = SnapToGridXZ(hit, def);
         if (ghostGO != null)
         {
-            ghostGO.transform.position = snapped;
+            ghostGO.transform.position = snapped + new Vector3(0f, 0.02f, 0f);
         }
 
         // Click to place
-        if (Input.GetMouseButtonDown(0))
+        // Ignore the initial click that selected the tool (click-through from UI)
+        if (suppressClickUntilMouseUp)
+        {
+            if (Input.GetMouseButtonUp(0)) suppressClickUntilMouseUp = false;
+        }
+        else if (Input.GetMouseButtonDown(0))
         {
             TryPlace(def, snapped);
         }
@@ -141,10 +151,19 @@ public class BuildPlacementTool : MonoBehaviour
         // Visuals: prefer real sprite from VisualDef.spritePath; fall back to white unit
         var sr = go.AddComponent<SpriteRenderer>();
         var spr = LoadSpriteFor(def);
-        if (spr != null) sr.sprite = spr; else sr.sprite = MakeUnitSprite();
+        if (spr != null)
+        {
+            sr.sprite = spr;
+        }
+        else
+        {
+            Debug.LogWarning("[Build] Sprite not found at Resources/" + (GetVisualDefFor(def)?.spritePath ?? "(null)") + ".png — using white fallback.");
+            sr.sprite = MakeUnitSprite();
+        }
         ApplyScaleForSpriteOrFallbackXZ(go, def, spr);
+        sr.sortingOrder = 100;
         // Set final position on ground with slight epsilon to avoid z-fighting
-        go.transform.position = new Vector3(pos.x, 0.01f, pos.z);
+        go.transform.position = new Vector3(pos.x, 0.03f, pos.z); // slight epsilon
 
         ClearTool(); // place once for MVP
     }
@@ -165,6 +184,17 @@ public class BuildPlacementTool : MonoBehaviour
         return new Vector3(x, 0f, z);
     }
 
+    bool TryGetCursorHit(out Vector3 hit)
+    {
+        hit = default;
+        if (cam == null) cam = Camera.main;
+        if (cam == null) return false;
+        var ray = cam.ScreenPointToRay(Input.mousePosition);
+        if (!groundPlane.Raycast(ray, out var enter)) return false;
+        hit = ray.GetPoint(enter); // y == 0 plane
+        return true;
+    }
+
     void EnsureGhost(BuildingDef def)
     {
         EnsureGhostDestroyed();
@@ -183,6 +213,7 @@ public class BuildPlacementTool : MonoBehaviour
         c.a = ghostAlpha;
         ghostSr.color = c;
         ApplyScaleForSpriteOrFallbackXZ(ghostGO, def, spr);
+        ghostSr.sortingOrder = 200;
     }
 
     void EnsureGhostDestroyed()


### PR DESCRIPTION
## Summary
- Keep generated build systems and HUD objects across scene loads
- Resize build palette more aggressively with usage tips
- Avoid click-through after arming the placement tool, place ghost under cursor, and warn if sprites are missing

## Testing
- `dotnet build Tools/XmlDefsTools/XmlDefsTools.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b27ced252c832484a16b28218e0481