### PR TITLE
Restore Build HUD visibility and ensure controller self-heals

### DIFF
--- a/Assets/Scripts/Build/BuildHUD.cs
+++ b/Assets/Scripts/Build/BuildHUD.cs
@@ -11,13 +11,6 @@ public class BuildHUD : MonoBehaviour
 
     void OnGUI()
     {
-        // Hide on intro/title screens if an IntroScreen surface exists and is visible.
-        try
-        {
-            var intro = FindAnyObjectByType<IntroScreen>();
-            if (intro != null && intro.isActiveAndEnabled) return;
-        } catch { /* safe if class not present */ }
-
         var ctrl = Ctrl;
         if (ctrl == null)
         {

--- a/Assets/Scripts/Build/BuildModeController.cs
+++ b/Assets/Scripts/Build/BuildModeController.cs
@@ -83,6 +83,13 @@ public class BuildModeController : MonoBehaviour
 
     private void Update()
     {
+        // Self-heal: if Instance was lost (scene change), ensure systems exist
+        if (Instance == null)
+        {
+            BuildBootstrap.Ensure();
+            Instance = this;
+        }
+
         // Basic hotkey (B) to toggle build mode
         if (Input.GetKeyDown(KeyCode.B))
         {


### PR DESCRIPTION
## Summary
- Remove intro-screen check so Build HUD is available on all screens
- Allow `BuildModeController` to reinitialize itself if its instance is lost, guaranteeing the `B` key works after scene changes

## Testing
- `dotnet build Tools/XmlDefsTools/XmlDefsTools.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68b27ed92988832485a15259cd9d1027