### PR TITLE
Scale IMGUI with DPI and harden build tools

### DIFF
--- a/Assets/Scripts/Build/BuildHUD.cs
+++ b/Assets/Scripts/Build/BuildHUD.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 /// <summary>
 /// Minimal header HUD that exposes a Build toggle and self-heals missing systems.
@@ -11,13 +12,31 @@ public class BuildHUD : MonoBehaviour
 
     void OnGUI()
     {
+        // Hide on intro/menu/title scenes
+        var sn = SceneManager.GetActiveScene().name;
+        if (!string.IsNullOrEmpty(sn))
+        {
+            var s = sn.ToLowerInvariant();
+            if (s.Contains("intro") || s.Contains("menu") || s.Contains("title")) return;
+        }
+
         var ctrl = Ctrl;
         if (ctrl == null)
         {
             BuildBootstrap.Ensure();
             ctrl = BuildModeController.Instance;
         }
-        GUILayout.BeginArea(HeaderRect, GUI.skin.window);
+
+        // Scale UI for high DPI
+        float scale = Mathf.Clamp(Mathf.Min(Screen.width / 1920f, Screen.height / 1080f), 1.0f, 2.5f);
+        var prevMatrix = GUI.matrix;
+        GUIUtility.ScaleAroundPivot(new Vector2(scale, scale), Vector2.zero);
+        var rect = new Rect(HeaderRect.x / scale, HeaderRect.y / scale, HeaderRect.width / scale, HeaderRect.height / scale);
+
+        var skin = GUI.skin;
+        int oldButton = skin.button.fontSize;
+        skin.button.fontSize = Mathf.RoundToInt(14 * scale);
+        GUILayout.BeginArea(rect, GUI.skin.window);
         GUILayout.BeginHorizontal();
         GUILayout.Label(ctrl != null && ctrl.IsActive ? "●" : "○", GUILayout.Width(20));
         if (GUILayout.Button("Build [B]", GUILayout.Height(20)))
@@ -26,6 +45,7 @@ public class BuildHUD : MonoBehaviour
         }
         GUILayout.EndHorizontal();
         GUILayout.EndArea();
+        skin.button.fontSize = oldButton;
+        GUI.matrix = prevMatrix;
     }
 }
-

--- a/Assets/StreamingAssets/Mods/Core/Defs/Visuals/ConstructionBoardVisual.xml
+++ b/Assets/StreamingAssets/Mods/Core/Defs/Visuals/ConstructionBoardVisual.xml
@@ -5,6 +5,6 @@
     <plane>XZ</plane>
     <shader_hint>Sprites/Default</shader_hint>
     <color>1,1,1,1</color>
-    <pivot>0.5,0.5</pivot>
+    <pivot>0.5,0.0</pivot>
   </Visual2DDef>
 </Defs>


### PR DESCRIPTION
## Summary
- Scale build HUD and palette fonts for high DPI and hide UI on intro/menu/title scenes
- Make placement tool more robust by reacquiring camera, updating ground plane, and debouncing click-through
- Adjust construction board pivot to bottom-center for better alignment

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b28183e9988324a67c8372a201c9fb