### PR TITLE
Wire UI and hotkey to Unity 6 input

### DIFF
--- a/Assets/Scripts/Build/BuildModeController.cs
+++ b/Assets/Scripts/Build/BuildModeController.cs
@@ -4,6 +4,9 @@ using System.Linq;
 // Assumes BuildingDef exists in your Defs namespace
 // If your project uses a different namespace, adjust the using accordingly.
 using FantasyColony.Defs;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 using UnityObject = UnityEngine.Object;
 
 public class BuildModeController : MonoBehaviour
@@ -90,8 +93,16 @@ public class BuildModeController : MonoBehaviour
             Instance = this;
         }
 
-        // Basic hotkey (B) to toggle build mode
-        if (Input.GetKeyDown(KeyCode.B))
+        // Basic hotkey (B) to toggle build mode (support both input backends)
+        bool pressed = false;
+#if ENABLE_INPUT_SYSTEM
+        if (Keyboard.current != null)
+            pressed |= Keyboard.current.bKey.wasPressedThisFrame;
+#endif
+#if ENABLE_LEGACY_INPUT_MANAGER || !ENABLE_INPUT_SYSTEM
+        pressed |= Input.GetKeyDown(KeyCode.B);
+#endif
+        if (pressed)
         {
             ToggleBuildMode();
             Debug.Log("[Build] Toggled via B → " + (_buildModeEnabled ? "ON" : "OFF"));


### PR DESCRIPTION
## Summary
- Ensure an EventSystem exists and attach the appropriate UI input module for the new or legacy backend.
- Make build button raycastable and guarantee EventSystem is present in gameplay scenes.
- Support toggling build mode with `B` across both Unity input systems.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2883f4f688324a1b717f638bcb85e