### PR TITLE
Ensure defs and Construction Board sprite load reliably

### DIFF
--- a/Assets/Scripts/Boot/BuildBootstrap.cs
+++ b/Assets/Scripts/Boot/BuildBootstrap.cs
@@ -8,6 +8,9 @@ using System.Linq;
 /// </summary>
 public static class BuildBootstrap
 {
+    // Ensure we load defs once per run to avoid races where DB appears empty
+    static bool _defsLoadedOnce = false;
+
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
     public static void EnsureOnLoad()
     {
@@ -28,18 +31,31 @@ public static class BuildBootstrap
         if (go.GetComponent<BuildPlacementTool>() == null)
             go.AddComponent<BuildPlacementTool>();
 
-        // Make sure defs are available
-        try
+        // Make sure defs are available (force an eager first-load once per run)
+        if (!_defsLoadedOnce)
         {
-            if (DefDatabase.Buildings == null || DefDatabase.Visuals == null ||
-                DefDatabase.Buildings.Count == 0 || DefDatabase.Visuals.Count == 0)
+            try
             {
                 DefDatabase.LoadAll();
+                _defsLoadedOnce = true;
+            }
+            catch
+            {
+                // ignore – bring-up should still run with fallbacks
             }
         }
-        catch
+        else
         {
-            // ignore – bring-up should still run with fallbacks
+            try
+            {
+                if (DefDatabase.Buildings == null || DefDatabase.Visuals == null ||
+                    DefDatabase.Buildings.Count == 0 || DefDatabase.Visuals.Count == 0)
+                    DefDatabase.LoadAll();
+            }
+            catch
+            {
+                // ignore – bring-up should still run with fallbacks
+            }
         }
 
         // Ensure there is a palette HUD

--- a/Assets/Scripts/Build/BuildPlacementTool.cs
+++ b/Assets/Scripts/Build/BuildPlacementTool.cs
@@ -145,16 +145,36 @@ public class BuildPlacementTool : MonoBehaviour
 
     Sprite LoadSpriteFor(BuildingDef def)
     {
+        // Primary path: via visual def
         var v = GetVisualDefFor(def);
         if (v != null && !string.IsNullOrEmpty(v.spritePath))
         {
-            var s = Resources.Load<Sprite>(v.spritePath);
-            if (s != null) return s;
+            var spr = Resources.Load<Sprite>(v.spritePath);
+            if (spr != null)
+            {
+                Debug.Log("[Build] Loaded sprite: " + spr.name + " (PPU=" + spr.pixelsPerUnit + ", path=" + v.spritePath + ")");
+                return spr;
+            }
             if (!_warnedSpriteMissing)
             {
                 Debug.LogWarning("[Build] Sprite NOT FOUND at Resources/" + v.spritePath + ".png – ensure it's Sprite(2D & UI), under Assets/Resources, no extension in path.");
                 _warnedSpriteMissing = true;
             }
+        }
+
+        // Direct fallback for Construction Board bring-up even when visual DB is missing
+        if (def != null && !string.IsNullOrEmpty(def.defName) &&
+            def.defName.ToLowerInvariant().Contains("constructionboard"))
+        {
+            const string directPath = "Sprites/ConstructionBoard";
+            var spr = Resources.Load<Sprite>(directPath);
+            if (spr != null)
+            {
+                Debug.Log("[Build] Loaded sprite via direct path fallback: " + spr.name + " (PPU=" + spr.pixelsPerUnit + ", path=" + directPath + ")");
+                return spr;
+            }
+            if (!_warnedSpriteMissing)
+                Debug.LogWarning("[Build] Sprite NOT FOUND at Resources/" + directPath + ".png – check asset path/type/import.");
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- Force DefDatabase to load once per run to prevent empty database races
- Add direct Resources fallback and logging for Construction Board sprite

## Testing
- ❌ `dotnet test` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b28cb798cc8324a4bb1d51605c6413