### PR TITLE
Improve build placement grid sizing and input gating

### DIFF
--- a/Assets/Scripts/Build/BuildPlacementTool.cs
+++ b/Assets/Scripts/Build/BuildPlacementTool.cs
@@ -8,6 +8,7 @@ using UnityObject = UnityEngine.Object;
 using UnityEngine.InputSystem;
 #endif
 using UnityEngine.EventSystems;
+using System.Collections.Generic;
 
 /// <summary>
 /// Minimal placement tool for the Construction Board bring-up:
@@ -37,6 +38,11 @@ public class BuildPlacementTool : MonoBehaviour
     // cached cell size set when arming/first hit
     float _cachedCellSize = -1f;
 
+    SimpleGridMap TryGetGrid()
+    {
+        return FindAnyObjectByType<SimpleGridMap>();
+    }
+
     void Start()
     {
         ctrl = GetComponent<BuildModeController>();
@@ -45,24 +51,24 @@ public class BuildPlacementTool : MonoBehaviour
 
     float GetCellSize()
     {
-        // Try to find a grid/map object with a cell size property/field.
-        // This is tolerant: it will use reflection to read common names.
-        float cell = 1f;
-        try
-        {
-            var any = FindAnyObjectByType<MonoBehaviour>();
-            if (any != null)
-            {
-                var type = any.GetType();
-                var csField = type.GetField("CellSize") ?? type.GetField("cellSize");
-                var csProp  = type.GetProperty("CellSize") ?? type.GetProperty("cellSize");
-                if (csField != null && csField.FieldType == typeof(float)) cell = (float)csField.GetValue(any);
-                else if (csProp != null && csProp.PropertyType == typeof(float)) cell = (float)csProp.GetValue(any);
-            }
-        }
-        catch { /* best-effort */ }
-        if (cell <= 0f || float.IsNaN(cell) || float.IsInfinity(cell)) cell = 1f;
+        var grid = TryGetGrid();
+        float cell = (grid != null) ? Mathf.Max(0.0001f, grid.tileSize) : 1f;
         return cell;
+    }
+
+    bool IsPointerOverUI(Vector2 screenPos)
+    {
+        if (EventSystem.current == null) return false;
+        var ed = new PointerEventData(EventSystem.current);
+        ed.position = screenPos;
+        var results = new List<RaycastResult>();
+        EventSystem.current.RaycastAll(ed, results);
+        return results.Count > 0;
+    }
+
+    Vector2Int WorldToGrid(Vector3 world, float cell)
+    {
+        return new Vector2Int(Mathf.RoundToInt(world.x / cell), Mathf.RoundToInt(world.z / cell));
     }
 
     public void SetTool(BuildTool tool)
@@ -97,7 +103,6 @@ public class BuildPlacementTool : MonoBehaviour
     void Update()
     {
         if (active == BuildTool.None) return;
-        if (cam == null || !cam.isActiveAndEnabled) cam = GetActiveCamera();
 
         var def = ctrl.SelectedBuildingDef;
         if (def == null)
@@ -107,6 +112,7 @@ public class BuildPlacementTool : MonoBehaviour
         }
         if (_cachedCellSize <= 0f) _cachedCellSize = GetCellSize();
         groundPlane = new Plane(Vector3.up, GetGroundY());
+        cam = GetActiveCamera();
 
         // Move ghost to snapped mouse position
         if (!TryGetCursorHit(out var hit))
@@ -125,7 +131,14 @@ public class BuildPlacementTool : MonoBehaviour
         // Ignore the initial click that selected the tool (click-through from UI)
         if (suppressClickUntilMouseUp)
         {
-            if (Input.GetMouseButtonUp(0) && Time.realtimeSinceStartup >= armBlockUntilTime)
+            bool released = false;
+#if ENABLE_INPUT_SYSTEM
+            if (Mouse.current != null) released |= Mouse.current.leftButton.wasReleasedThisFrame;
+#endif
+#if ENABLE_LEGACY_INPUT_MANAGER || !ENABLE_INPUT_SYSTEM
+            released |= Input.GetMouseButtonUp(0);
+#endif
+            if (released && Time.realtimeSinceStartup >= armBlockUntilTime)
                 suppressClickUntilMouseUp = false;
         }
         else
@@ -138,8 +151,8 @@ public class BuildPlacementTool : MonoBehaviour
             clickDown |= Input.GetMouseButtonDown(0);
 #endif
             // Avoid placing when pointer over UI
-            if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
-                clickDown = false;
+            var mp = GetMouseScreenPos();
+            if (IsPointerOverUI(mp)) clickDown = false;
 
             if (clickDown)
             {
@@ -277,12 +290,26 @@ public class BuildPlacementTool : MonoBehaviour
     void ApplyScaleForSpriteOrFallbackXZ(GameObject go, BuildingDef def, Sprite spriteOrNull)
     {
         if (_cachedCellSize <= 0f) _cachedCellSize = GetCellSize();
-        var scale = ComputeScaleForSprite(spriteOrNull, def);
-        // Ensure scale reflects grid squares instead of raw world units
-        scale.x *= _cachedCellSize;
-        scale.y *= _cachedCellSize;
-        // Optional visual-upsize: double the board if desired
-        // if (def.defName.Contains("ConstructionBoard")) { scale *= 2f; }
+        // Force exact grid footprint in world space: width × height tiles
+        float targetW = Mathf.Max(1, def.width) * _cachedCellSize;
+        float targetH = Mathf.Max(1, def.height) * _cachedCellSize;
+        Vector2 visualSize;
+        if (spriteOrNull != null)
+        {
+            // sprite.bounds is in world units at scale 1; for default import this is pixels/PPU
+            visualSize = spriteOrNull.bounds.size;
+        }
+        else
+        {
+            // fallback white unit is 1x1 in our factory
+            visualSize = Vector2.one;
+        }
+        float sx = (visualSize.x == 0) ? 1f : (targetW / visualSize.x);
+        float sy = (visualSize.y == 0) ? 1f : (targetH / visualSize.y);
+        var scale = new Vector3(sx, sy, 1f);
+
+        // Optional: double size (visual-only) → uncomment if desired
+        // if (def.defName.Contains("ConstructionBoard")) scale *= 2f;
         go.transform.localScale = scale;
         // Lay the sprite flat on XZ ground (face camera looking down -Y)
         go.transform.rotation = Quaternion.Euler(90f, 0f, 0f);
@@ -332,7 +359,9 @@ public class BuildPlacementTool : MonoBehaviour
         sr.sortingOrder = 100;
         // Set final position on ground with slight epsilon to avoid z-fighting
         go.transform.position = new Vector3(pos.x, 0.03f, pos.z); // slight epsilon
-        Debug.Log($"[Build] Placed {def.defName} at world {pos} (cellSize={_cachedCellSize})");
+        var cell = (_cachedCellSize > 0f) ? _cachedCellSize : GetCellSize();
+        var g = WorldToGrid(pos, cell);
+        Debug.Log($"[Build] Placed {def.defName} at world {pos} -> grid {g} (cellSize={cell})");
 
         ClearTool(); // place once for MVP
     }


### PR DESCRIPTION
## Summary
- Use `SimpleGridMap.tileSize` to size placement visuals and compute grid coordinates
- Raycast UI to block placement clicks and handle both input systems' press/release events
- Log grid coordinates when placing buildings and scale sprites to exact grid squares

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b293aa03e48324887d73effc6c094c