### PR TITLE
Restart finds intro scene and cleans up pause canvas

### DIFF
--- a/Assets/Scripts/Boot/HardRestart.cs
+++ b/Assets/Scripts/Boot/HardRestart.cs
@@ -4,7 +4,7 @@ using UnityEngine.EventSystems;
 
 public static class HardRestart
 {
-    public static void RebootToFirstScene()
+    public static void RebootToIntro()
     {
         Time.timeScale = 1f;
 
@@ -12,6 +12,7 @@ public static class HardRestart
         DestroyIfExists("BuildSystems (Auto)");
         DestroyIfExists("BuildPalette (Auto)");
         DestroyIfExists("BuildCanvas (Auto)");
+        DestroyIfExists("PauseCanvas (Auto)");
 
         // Destroy any EventSystem we created
         var es = Object.FindFirstObjectByType<EventSystem>();
@@ -22,8 +23,25 @@ public static class HardRestart
         var flag = bb.GetField("_defsLoadedOnce", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
         if (flag != null) flag.SetValue(null, false);
 
-        // Reload first scene (intro)
-        SceneManager.LoadScene(0);
+        // Choose intro-like scene by name/path; fallback to index 0
+        int target = FindIntroSceneIndex();
+        Debug.Log("[HardRestart] Rebooting to scene index " + target + " (" + SceneUtility.GetScenePathByBuildIndex(target) + ")");
+        SceneManager.LoadScene(target);
+    }
+
+    static int FindIntroSceneIndex()
+    {
+        int count = SceneManager.sceneCountInBuildSettings;
+        if (count <= 0) return 0;
+        for (int i = 0; i < count; i++)
+        {
+            var path = SceneUtility.GetScenePathByBuildIndex(i);
+            if (string.IsNullOrEmpty(path)) continue;
+            var low = path.ToLowerInvariant();
+            if (low.Contains("intro") || low.Contains("title") || low.Contains("menu") || low.Contains("start"))
+                return i;
+        }
+        return 0;
     }
 
     static void DestroyIfExists(string name)

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -21,7 +21,12 @@ public class PauseMenuController : MonoBehaviour
     static void Init()
     {
         // Create a driver that survives scene loads
-        var existing = GameObject.FindObjectOfType<PauseMenuController>();
+        PauseMenuController existing = null;
+#if UNITY_2023_1_OR_NEWER
+        existing = FindFirstObjectByType<PauseMenuController>();
+#else
+        existing = FindObjectOfType<PauseMenuController>();
+#endif
         if (existing == null)
         {
             var go = new GameObject("PauseMenuController");
@@ -114,7 +119,7 @@ public class PauseMenuController : MonoBehaviour
         restart.onClick.AddListener(() =>
         {
             Hide();
-            HardRestart.RebootToFirstScene();
+            HardRestart.RebootToIntro();
         });
         var exit = BuildButton(panel.transform, "Exit", new Vector2(0, -80));
         exit.onClick.AddListener(() =>


### PR DESCRIPTION
## Summary
- Revise HardRestart to clean persistent pause canvas and load first intro/title scene dynamically
- Guard PauseMenuController with newer `FindFirstObjectByType` API and route Restart button to new reboot method

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a160bc8c8324b1e60d02c117bc98