### PR TITLE
Handle boot scene capture and cleanup on hard restart

### DIFF
--- a/Assets/Scripts/Boot/BootSession.cs
+++ b/Assets/Scripts/Boot/BootSession.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Records the scene the app launched into so we can "full reboot" back to it.
+/// </summary>
+public static class BootSession
+{
+    public static int InitialSceneIndex { get; private set; } = -1;
+    public static string InitialScenePath { get; private set; } = null;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void Capture()
+    {
+        var active = SceneManager.GetActiveScene();
+        InitialSceneIndex = active.buildIndex;
+        InitialScenePath = active.path;
+        Debug.Log($"[BootSession] Captured initial scene index={InitialSceneIndex} path={InitialScenePath}");
+    }
+}

--- a/Assets/Scripts/Boot/BootSession.cs.meta
+++ b/Assets/Scripts/Boot/BootSession.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9f396c9410cc4b999bfa36dc35d71f5d

--- a/Assets/Scripts/Boot/HardRestart.cs
+++ b/Assets/Scripts/Boot/HardRestart.cs
@@ -13,6 +13,7 @@ public static class HardRestart
         DestroyIfExists("BuildPalette (Auto)");
         DestroyIfExists("BuildCanvas (Auto)");
         DestroyIfExists("PauseCanvas (Auto)");
+        DestroyIfExists("PauseMenuController");
 
         // Destroy any EventSystem we created
         var es = Object.FindFirstObjectByType<EventSystem>();
@@ -23,8 +24,15 @@ public static class HardRestart
         var flag = bb.GetField("_defsLoadedOnce", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
         if (flag != null) flag.SetValue(null, false);
 
-        // Choose intro-like scene by name/path; fallback to index 0
-        int target = FindIntroSceneIndex();
+        // Choose intro scene:
+        // 1) The scene we launched into (BootSession)
+        // 2) intro/title/menu heuristic
+        // 3) index 0 fallback
+        int target = -1;
+        if (BootSession.InitialSceneIndex >= 0)
+            target = BootSession.InitialSceneIndex;
+        else
+            target = FindIntroSceneIndex();
         Debug.Log("[HardRestart] Rebooting to scene index " + target + " (" + SceneUtility.GetScenePathByBuildIndex(target) + ")");
         SceneManager.LoadScene(target);
     }

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -60,6 +60,7 @@ public class PauseMenuController : MonoBehaviour
         _root.SetActive(true);
         Time.timeScale = 0f;
         IsPaused = true;
+        Debug.Log("[Pause] Shown");
     }
 
     public void Hide()
@@ -67,6 +68,7 @@ public class PauseMenuController : MonoBehaviour
         if (_root != null) _root.SetActive(false);
         Time.timeScale = 1f;
         IsPaused = false;
+        Debug.Log("[Pause] Hidden");
     }
 
     void EnsureUI()


### PR DESCRIPTION
## Summary
- Record the initial scene at startup
- Hard restart now returns to the startup scene and cleans pause controller objects
- Add logs when the pause menu shows/hides

## Testing
- `dotnet build Tools/XmlDefsTools/XmlDefsTools.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a3827b488324b72377de1997cf6e