### PR TITLE
Ensure Intro overlay shows at boot and hides conflicting UI

### DIFF
--- a/Assets/Scripts/Boot/BuildUIBootstrap.cs
+++ b/Assets/Scripts/Boot/BuildUIBootstrap.cs
@@ -78,16 +78,7 @@ public static class BuildUIBootstrap
         var canvas = GameObject.Find(CanvasName);
 
         // Destroy/hide if on an intro/menu scene or the scene-less intro overlay is visible
-        bool introOverlayVisible = false;
-        var introType = System.Type.GetType("IntroScreen");
-        if (introType != null)
-        {
-            var prop = introType.GetProperty("IsVisible", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-            if (prop != null)
-            {
-                introOverlayVisible = (bool)prop.GetValue(null);
-            }
-        }
+        bool introOverlayVisible = IntroScreen.Instance != null && IntroScreen.IsVisible;
 
         if (IsIntroLike(active) || introOverlayVisible)
         {

--- a/Assets/Scripts/UI/IntroScreen.cs
+++ b/Assets/Scripts/UI/IntroScreen.cs
@@ -24,6 +24,17 @@ public class IntroScreen : MonoBehaviour
         IsVisible = showMenu;
     }
 
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    static void EnsureOnBoot()
+    {
+        if (Instance == null)
+        {
+            var go = new GameObject("IntroScreen (Auto)");
+            go.AddComponent<IntroScreen>();
+        }
+        Instance.SetVisible(true);
+    }
+
     public void SetVisible(bool show)
     {
         showMenu = show;

--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -39,6 +39,8 @@ public class PauseMenuController : MonoBehaviour
     {
         // Esc toggles pause
         bool esc = false;
+        // Do not toggle pause when the Intro overlay is visible
+        if (IntroScreen.Instance != null && IntroScreen.IsVisible) return;
 #if ENABLE_INPUT_SYSTEM
         if (Keyboard.current != null) esc |= Keyboard.current.escapeKey.wasPressedThisFrame;
 #endif


### PR DESCRIPTION
## Summary
- Instantiate and display IntroScreen automatically after scene load
- Skip Build UI creation when Intro overlay is visible
- Avoid ESC-based pause toggling while Intro overlay is active

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2aea460908324b44ad614e2f75cbd