### PR TITLE
Add IntroScreen compatibility shim delegating to AppBootstrap

### DIFF
--- a/Assets/Scripts/UI/IntroScreenShim.cs
+++ b/Assets/Scripts/UI/IntroScreenShim.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+/// <summary>
+/// Compatibility shim for legacy code that references `IntroScreen`.
+/// Delegates behavior to AppBootstrap's intro overlay discovery/show/hide.
+/// This allows existing calls like `IntroScreen.ShowIntro()` and checks of
+/// `IntroScreen.IsVisible` to keep working without depending on a specific
+/// intro implementation or scene.
+/// </summary>
+public class IntroScreen : MonoBehaviour
+{
+    /// <summary>
+    /// Returns whether any intro/title/menu overlay is currently visible.
+    /// </summary>
+    public static bool IsVisible
+    {
+        get => AppBootstrap.IsIntroVisible();
+        set
+        {
+            if (value) AppBootstrap.ShowIntroOverlay();
+            else AppBootstrap.HideIntroOverlay();
+        }
+    }
+
+    /// <summary>
+    /// Legacy entry point to show the intro overlay.
+    /// </summary>
+    public static void ShowIntro() => AppBootstrap.ShowIntroOverlay();
+
+    /// <summary>
+    /// If some legacy bootstrap does `new GameObject(...).AddComponent<IntroScreen>()`,
+    /// keep the object around but delegate visibility to AppBootstrap.
+    /// </summary>
+    void Awake()
+    {
+        // Do not create any UI here; AppBootstrap handles discovery/fallback.
+        DontDestroyOnLoad(gameObject);
+    }
+
+    // Prevent accidental IMGUI drawing from legacy stubs.
+    void OnGUI() { /* intentionally empty; real intro overlay is external */ }
+}

--- a/Assets/Scripts/UI/IntroScreenShim.cs.meta
+++ b/Assets/Scripts/UI/IntroScreenShim.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e6233350ee74d1d8948ff80f53b8732
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add IntroScreen shim delegating visibility checks to AppBootstrap
- include .meta file for Unity

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b49536a48324beb876e1b4871384