### PR TITLE
Fix type mismatch in IntroMenuOverlay initialization

### DIFF
--- a/Assets/Scripts/UI/IntroMenuOverlay.cs
+++ b/Assets/Scripts/UI/IntroMenuOverlay.cs
@@ -84,8 +84,8 @@ public class IntroMenuOverlay : MonoBehaviour
         var bLarge  = BuildToggleButton(sizes.transform, "Large\n128×128",new Vector2( 70,  0), () => SetSize(MapSize.Large));
         var bHuge   = BuildToggleButton(sizes.transform, "Huge\n192×192", new Vector2( 210, 0), () => SetSize(MapSize.Huge));
 
-        // Initial visual state
-        Highlight(bLarge, true);
+        // Initial visual state (Large by default)
+        SetSize(MapSize.Large);
 
         // Start / Quit
         var start = BuildButton(panel.transform, "Start", new Vector2(0, -80));


### PR DESCRIPTION
## Summary
- Initialize map size buttons via `SetSize(MapSize.Large)` instead of `Highlight(bLarge, true)`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2baf98b9483248b3656df37c95c95