### PR TITLE
Add robust world-start flow triggered from intro menu

### DIFF
--- a/Assets/Scripts/UI/IntroMenuOverlay.cs
+++ b/Assets/Scripts/UI/IntroMenuOverlay.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 #if ENABLE_INPUT_SYSTEM
@@ -23,6 +24,7 @@ public class IntroMenuOverlay : MonoBehaviour
     static readonly Vector2Int Huge  = new Vector2Int(192, 192);
 
     static GameObject _root;
+    static IntroMenuOverlay _beh; // runner for coroutines
     static MapSize _selected = MapSize.Large; // default
 
     public static void Ensure()
@@ -131,8 +133,8 @@ public class IntroMenuOverlay : MonoBehaviour
         start.onClick.AddListener(() =>
         {
             var dims = GetDims(_selected);
-            TryStartWorld(dims.x, dims.y);
-            Hide();
+            if (_beh == null) _beh = _root.AddComponent<IntroMenuOverlay>();
+            _beh.StartCoroutine(StartWorldFlow(dims.x, dims.y, _selected));
         });
 
         var quit = BuildButton(panel.transform, "Quit", new Vector2(0, -150));
@@ -235,42 +237,7 @@ public class IntroMenuOverlay : MonoBehaviour
         return t;
     }
 
-    static void TryStartWorld(int w, int h)
-    {
-        // Preferred path: WorldBootstrap.GenerateDefaultGrid(int,int)
-        var wbType = FindTypeByNameContains("WorldBootstrap");
-        if (wbType != null)
-        {
-            var mi = wbType.GetMethod("GenerateDefaultGrid", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(int), typeof(int) }, null);
-            if (mi != null)
-            {
-                Debug.Log($"[IntroMenu] Starting world via WorldBootstrap.GenerateDefaultGrid({w},{h})");
-                mi.Invoke(null, new object[] { w, h });
-                return;
-            }
-        }
-
-        // Fallbacks: common method names on any bootstrap-like type
-        string[] names = { "GenerateWorld", "CreateWorld", "StartNewGame", "StartGame", "BootWorld" };
-        var tb = FindTypeByNameContains("Bootstrap");
-        if (tb != null)
-        {
-            foreach (var n in names)
-            {
-                var mi = tb.GetMethod(n, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(int), typeof(int) }, null)
-                      ?? tb.GetMethod(n, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, Type.EmptyTypes, null);
-                if (mi != null)
-                {
-                    Debug.Log($"[IntroMenu] Starting world via {tb.Name}.{n}({(mi.GetParameters().Length == 2 ? $"{w},{h}" : "")})");
-                    var args = mi.GetParameters().Length == 2 ? new object[] { w, h } : null;
-                    mi.Invoke(null, args);
-                    return;
-                }
-            }
-        }
-
-        Debug.LogWarning("[IntroMenu] No world bootstrap method found; overlay will hide but no world was created.");
-    }
+    static string PresetName(MapSize s) => s.ToString();
 
     static Type FindTypeByNameContains(string token)
     {
@@ -283,6 +250,208 @@ public class IntroMenuOverlay : MonoBehaviour
             {
                 if (t.Name.ToLowerInvariant().Contains(token))
                     return t;
+            }
+        }
+        return null;
+    }
+
+    // ---------------- Robust start flow ----------------
+
+    IEnumerator StartWorldFlow(int w, int h, MapSize preset)
+    {
+        // 1) Try to start world using robust discovery
+        string selected = null;
+        bool invoked = TryStartWorldRobust(w, h, preset, out selected);
+        if (!invoked)
+        {
+            Debug.LogError("[IntroMenu] Could not find a world start method. Intro will remain visible.");
+            yield break;
+        }
+        Debug.Log("[IntroMenu] Invoked: " + selected);
+
+        // 2) Wait a frame to let world construct
+        yield return null;
+
+        // 3) Verify grid exists
+        var grid = UnityEngine.Object.FindFirstObjectByType<SimpleGridMap>();
+        if (grid == null)
+        {
+            Debug.LogError("[IntroMenu] World grid not detected after start call. Intro will remain visible.");
+            yield break;
+        }
+
+        // 4) Try to spawn test pawns if not already present
+        if (!HasAnyPawns())
+        {
+            TrySpawnPawnsRobust(2);
+            yield return null;
+        }
+
+        // 5) Hide intro (success)
+        Hide();
+    }
+
+    static bool HasAnyPawns()
+    {
+        var all = UnityEngine.Object.FindObjectsByType<MonoBehaviour>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+        foreach (var mb in all)
+        {
+            var n = mb.GetType().Name.ToLowerInvariant();
+            if (n.Contains("pawn") || n.Contains("agent") || n.Contains("actor"))
+                return true;
+        }
+        return false;
+    }
+
+    static bool TryStartWorldRobust(int w, int h, MapSize preset, out string selected)
+    {
+        selected = null;
+        string[] typeOrder =
+        {
+            "WorldBootstrap","GameBootstrap","WorldBuilder","MapGenerator","GridBootstrap","WorldInitializer","GameInit"
+        };
+        string[] methodOrder =
+        {
+            "GenerateDefaultGrid","StartNewGame","StartGame","GenerateWorld","CreateWorld","CreateGrid","InitWorld","BootWorld"
+        };
+
+        // List candidates in deterministic order (typeOrder × methodOrder)
+        var asms = AppDomain.CurrentDomain.GetAssemblies();
+        foreach (var tName in typeOrder)
+        {
+            var t = FindExactType(asms, tName);
+            if (t == null) continue;
+            foreach (var mName in methodOrder)
+            {
+                // Try signatures in order: (int,int), (Vector2Int), (), (string)
+                var mi_ii = t.GetMethod(mName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(int), typeof(int) }, null);
+                if (mi_ii != null)
+                {
+                    mi_ii.Invoke(null, new object[] { w, h });
+                    selected = $"{t.Name}.{mName}(int,int)";
+                    return true;
+                }
+                var vec2 = typeof(Vector2Int);
+                var mi_v = t.GetMethod(mName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new[] { vec2 }, null);
+                if (mi_v != null)
+                {
+                    var size = new Vector2Int(w, h);
+                    mi_v.Invoke(null, new object[] { size });
+                    selected = $"{t.Name}.{mName}(Vector2Int)";
+                    return true;
+                }
+                var mi_0 = t.GetMethod(mName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, Type.EmptyTypes, null);
+                if (mi_0 != null)
+                {
+                    mi_0.Invoke(null, null);
+                    selected = $"{t.Name}.{mName}()";
+                    return true;
+                }
+                var mi_s = t.GetMethod(mName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(string) }, null);
+                if (mi_s != null)
+                {
+                    mi_s.Invoke(null, new object[] { PresetName(preset) });
+                    selected = $"{t.Name}.{mName}(string)";
+                    return true;
+                }
+            }
+        }
+
+        // If nothing matched in the preferred type list, do a broader sweep across all types named *Bootstrap* or *Generator*
+        foreach (var asm in asms)
+        {
+            Type[] types;
+            try { types = asm.GetTypes(); } catch { continue; }
+            foreach (var t in types)
+            {
+                var tn = t.Name.ToLowerInvariant();
+                if (!tn.Contains("bootstrap") && !tn.Contains("generator") && !tn.Contains("builder")) continue;
+                foreach (var mName in methodOrder)
+                {
+                    var mi_ii = t.GetMethod(mName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(int), typeof(int) }, null);
+                    if (mi_ii != null)
+                    {
+                        mi_ii.Invoke(null, new object[] { w, h });
+                        selected = $"{t.Name}.{mName}(int,int)";
+                        return true;
+                    }
+                    var vec2 = typeof(Vector2Int);
+                    var mi_v = t.GetMethod(mName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new[] { vec2 }, null);
+                    if (mi_v != null)
+                    {
+                        var size = new Vector2Int(w, h);
+                        mi_v.Invoke(null, new object[] { size });
+                        selected = $"{t.Name}.{mName}(Vector2Int)";
+                        return true;
+                    }
+                    var mi_0 = t.GetMethod(mName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, Type.EmptyTypes, null);
+                    if (mi_0 != null)
+                    {
+                        mi_0.Invoke(null, null);
+                        selected = $"{t.Name}.{mName}()";
+                        return true;
+                    }
+                    var mi_s = t.GetMethod(mName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(string) }, null);
+                    if (mi_s != null)
+                    {
+                        mi_s.Invoke(null, new object[] { PresetName(preset) });
+                        selected = $"{t.Name}.{mName}(string)";
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static void TrySpawnPawnsRobust(int desiredCount)
+    {
+        string[] typeHints = { "Pawn", "Actor", "Agent", "Spawner", "Bootstrap" };
+        string[] methodNames = { "SpawnTestPawns", "SpawnDefaultPawns", "SpawnPawns", "CreateTestActors", "CreateDefaultPawns" };
+
+        var asms = AppDomain.CurrentDomain.GetAssemblies();
+        foreach (var asm in asms)
+        {
+            Type[] types;
+            try { types = asm.GetTypes(); } catch { continue; }
+            foreach (var t in types)
+            {
+                var tn = t.Name.ToLowerInvariant();
+                if (!typeHints.Any(h => tn.Contains(h.ToLowerInvariant()))) continue;
+                foreach (var mn in methodNames)
+                {
+                    // Try (int) then ()
+                    var mi_i = t.GetMethod(mn, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(int) }, null);
+                    if (mi_i != null)
+                    {
+                        mi_i.Invoke(null, new object[] { desiredCount });
+                        Debug.Log($"[IntroMenu] Invoked {t.Name}.{mn}(int) to spawn pawns.");
+                        return;
+                    }
+                    var mi_0 = t.GetMethod(mn, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, Type.EmptyTypes, null);
+                    if (mi_0 != null)
+                    {
+                        mi_0.Invoke(null, null);
+                        Debug.Log($"[IntroMenu] Invoked {t.Name}.{mn}() to spawn pawns.");
+                        return;
+                    }
+                }
+            }
+        }
+        // Not fatal—map is up; just no test pawns
+        Debug.Log("[IntroMenu] No pawn spawner entrypoint found (map started).");
+    }
+
+    static Type FindExactType(Assembly[] asms, string name)
+    {
+        foreach (var asm in asms)
+        {
+            Type[] types;
+            try { types = asm.GetTypes(); } catch { continue; }
+            foreach (var t in types)
+            {
+                if (t.Name.Equals(name, StringComparison.Ordinal)) return t;
             }
         }
         return null;


### PR DESCRIPTION
## Summary
- Start button now launches coroutine that locates world bootstrap, verifies map creation and spawns test pawns before hiding intro
- Added exhaustive search across common bootstrap types and signatures with detailed diagnostics

## Testing
- ⚠️ `dotnet test` *(command not found)*
- ⚠️ `apt-get update` *(403 - repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c0c4ba5083248bec35a901b62836