### PR TITLE
Fix CS0120: call instance coroutine via _beh.StartWorldFlow(...) when starting the world

### DIFF
--- a/Assets/Scripts/UI/IntroMenuOverlay.cs
+++ b/Assets/Scripts/UI/IntroMenuOverlay.cs
@@ -134,7 +134,7 @@ public class IntroMenuOverlay : MonoBehaviour
         {
             var dims = GetDims(_selected);
             if (_beh == null) _beh = _root.AddComponent<IntroMenuOverlay>();
-            _beh.StartCoroutine(StartWorldFlow(dims.x, dims.y, _selected));
+            _beh.StartCoroutine(_beh.StartWorldFlow(dims.x, dims.y, _selected));
         });
 
         var quit = BuildButton(panel.transform, "Quit", new Vector2(0, -150));


### PR DESCRIPTION
## Summary
- Ensure Start button uses `_beh.StartWorldFlow` when launching the world to avoid CS0120 errors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c315245483249c456eb1252cf0f3