### PR TITLE
Replace deprecated Object.FindObjectOfType usage

### DIFF
--- a/Assets/Scripts/Boot/TestMapStarter.cs
+++ b/Assets/Scripts/Boot/TestMapStarter.cs
@@ -159,8 +159,8 @@ public static class TestMapStarter
 
     private static void EnsurePawnInteractionManager()
     {
-        var existing = UnityEngine.Object.FindObjectOfType<MonoBehaviour>(true);
-        var pim = UnityEngine.Object.FindObjectOfType<PawnInteractionManager>(true);
+        _ = UnityEngine.Object.FindFirstObjectByType<MonoBehaviour>(UnityEngine.FindObjectsInactive.Include);
+        var pim = UnityEngine.Object.FindFirstObjectByType<PawnInteractionManager>(UnityEngine.FindObjectsInactive.Include);
         if (pim != null) return;
 
         var root = GameObject.Find("GameSystems (Auto)") ?? new GameObject("GameSystems (Auto)");


### PR DESCRIPTION
## Summary
- replace deprecated FindObjectOfType calls with FindFirstObjectByType to satisfy newer Unity APIs

## Testing
- `dotnet build Tools/XmlDefsTools/XmlDefsTools.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d927e5fc832480434ab590d339d6