### PR TITLE
Expose build UI refresh entry point and trigger after intro overlay

### DIFF
--- a/Assets/Scripts/Boot/BuildUIBootstrap.cs
+++ b/Assets/Scripts/Boot/BuildUIBootstrap.cs
@@ -72,7 +72,7 @@ public static class BuildUIBootstrap
 #endif
     }
 
-    static void EnsureForCurrentScene()
+    public static void EnsureForCurrentScene()
     {
         var active = SceneManager.GetActiveScene().name;
         var canvas = GameObject.Find(CanvasName);

--- a/Assets/Scripts/UI/IntroMenuOverlay.cs
+++ b/Assets/Scripts/UI/IntroMenuOverlay.cs
@@ -40,6 +40,7 @@ public class IntroMenuOverlay : MonoBehaviour
     public static void Hide()
     {
         if (_root != null) _root.SetActive(false);
+        BuildUIBootstrap.EnsureForCurrentScene();
     }
 
     static void EnsureEventSystem()


### PR DESCRIPTION
## Summary
- Make `BuildUIBootstrap.EnsureForCurrentScene` public so other modules can force a rebuild
- Call `BuildUIBootstrap.EnsureForCurrentScene` when the intro overlay hides to spawn the Build button after starting the world

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db3120308324bf9cdbe79a1de3e8