### PR TITLE
Skip IntroScreen shim when locating intro overlay

### DIFF
--- a/Assets/Scripts/Boot/AppBootstrap.cs
+++ b/Assets/Scripts/Boot/AppBootstrap.cs
@@ -99,6 +99,7 @@ public static class AppBootstrap
         var all = UnityEngine.Object.FindObjectsByType<MonoBehaviour>(FindObjectsInactive.Include, FindObjectsSortMode.None);
         foreach (var mb in all)
         {
+            if (mb is IntroScreen) continue;
             var n = mb.GetType().Name.ToLowerInvariant();
             if (IntroTypeHints.Any(h => n.Contains(h))) return mb;
         }


### PR DESCRIPTION
## Summary
- Ignore the compatibility `IntroScreen` shim when searching for the real intro overlay

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dce215e88324b85512a4edf72cfe