### PR TITLE
Skip PauseMenuController in intro detection

### DIFF
--- a/Assets/Scripts/Boot/AppBootstrap.cs
+++ b/Assets/Scripts/Boot/AppBootstrap.cs
@@ -100,6 +100,7 @@ public static class AppBootstrap
         foreach (var mb in all)
         {
             if (mb is IntroScreen) continue;
+            if (mb is PauseMenuController) continue;
             var n = mb.GetType().Name.ToLowerInvariant();
             if (IntroTypeHints.Any(h => n.Contains(h))) return mb;
         }


### PR DESCRIPTION
## Summary
- ignore PauseMenuController when searching for intro overlays to avoid false positives

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2de97efd08324a31555b01ffe13f1