### PR TITLE
Allow Esc to close pause menu when intro visible

### DIFF
--- a/Assets/Scripts/UI/PauseMenuController.cs
+++ b/Assets/Scripts/UI/PauseMenuController.cs
@@ -41,7 +41,7 @@ public class PauseMenuController : MonoBehaviour
         // Esc toggles pause
         bool esc = false;
         // Do not toggle pause when any Intro overlay is visible
-        if (AppBootstrap.IsIntroVisible()) return;
+        if (AppBootstrap.IsIntroVisible() && !IsPaused) return;
 #if ENABLE_INPUT_SYSTEM
         if (Keyboard.current != null) esc |= Keyboard.current.escapeKey.wasPressedThisFrame;
 #endif


### PR DESCRIPTION
## Summary
- Allow Escape key to close the pause menu even if an intro overlay is visible

## Testing
- `csc Assets/Scripts/UI/PauseMenuController.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2de99102c8324bb33436140a39ffe