### PR TITLE
Ensure build UI returns after hiding intro overlay

### DIFF
--- a/Assets/Scripts/Boot/AppBootstrap.cs
+++ b/Assets/Scripts/Boot/AppBootstrap.cs
@@ -53,16 +53,27 @@ public static class AppBootstrap
     /// <summary>Hides any intro overlay (real or fallback).</summary>
     public static void HideIntroOverlay()
     {
-        if (IntroMenuOverlay.IsOpen) { IntroMenuOverlay.Hide(); return; }
+        if (IntroMenuOverlay.IsOpen)
+        {
+            IntroMenuOverlay.Hide();
+            BuildUIBootstrap.EnsureForCurrentScene();
+            return;
+        }
         var comp = FindIntroComponentInScene();
         if (comp != null)
         {
-            if (TryInvokeHide(comp)) return;
+            if (TryInvokeHide(comp))
+            {
+                BuildUIBootstrap.EnsureForCurrentScene();
+                return;
+            }
             TrySetVisibleFlag(comp, false);
             comp.gameObject.SetActive(false);
+            BuildUIBootstrap.EnsureForCurrentScene();
             return;
         }
         IntroOverlayFallback.HideIfPresent();
+        BuildUIBootstrap.EnsureForCurrentScene();
     }
 
     // --- internals ---


### PR DESCRIPTION
## Summary
- Ensure build UI bootstrap runs when any intro overlay is hidden

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e0e032c883249205ccfe81d32ee0