### PR TITLE
Remove scene-name gating for Build UI

### DIFF
--- a/Assets/Scripts/Boot/BuildUIBootstrap.cs
+++ b/Assets/Scripts/Boot/BuildUIBootstrap.cs
@@ -29,9 +29,10 @@ public static class BuildUIBootstrap
 
     static bool IsIntroLike(string sceneName)
     {
-        if (string.IsNullOrEmpty(sceneName)) return false;
-        var s = sceneName.ToLowerInvariant();
-        return s.Contains("intro") || s.Contains("menu") || s.Contains("title");
+#if UNITY_EDITOR
+        UnityEngine.Debug.Log("[BuildUI] IsIntroLike disabled; relying on overlay visibility only.");
+#endif
+        return false;
     }
 
     static void EnsureEventSystem()


### PR DESCRIPTION
## Summary
- avoid treating scenes with "menu" as intro-like so Build button appears on maps
- remove scene-name check entirely and rely on intro overlay visibility

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e710f1688324af4a417a4f25e8fa