### PR TITLE
Simplify intro overlay visibility and remove menu heuristic

### DIFF
--- a/Assets/Scripts/Boot/AppBootstrap.cs
+++ b/Assets/Scripts/Boot/AppBootstrap.cs
@@ -33,14 +33,8 @@ public static class AppBootstrap
     /// <summary>Returns true if an intro-like overlay is visible.</summary>
     public static bool IsIntroVisible()
     {
-        if (IntroMenuOverlay.IsOpen) return true;
-        var comp = FindIntroComponentInScene();
-        if (comp is IIntroOverlay)
-        {
-            if (TryGetVisibleFlag(comp, out bool vis)) return vis;
-            return comp.isActiveAndEnabled && comp.gameObject.activeInHierarchy;
-        }
-        return false;
+        var intro = UnityEngine.Object.FindObjectOfType<IntroMenuOverlay>(true);
+        return intro != null && intro.gameObject.activeInHierarchy;
     }
 
     /// <summary>Shows the intro overlay (prefer the project's real one; otherwise spawn a fallback).</summary>
@@ -56,26 +50,8 @@ public static class AppBootstrap
     /// <summary>Hides any intro overlay (real or fallback).</summary>
     public static void HideIntroOverlay()
     {
-        if (IntroMenuOverlay.IsOpen)
-        {
-            IntroMenuOverlay.Hide();
-            BuildUIBootstrap.EnsureForCurrentScene();
-            return;
-        }
-        var comp = FindIntroComponentInScene();
-        if (comp != null)
-        {
-            if (TryInvokeHide(comp))
-            {
-                BuildUIBootstrap.EnsureForCurrentScene();
-                return;
-            }
-            TrySetVisibleFlag(comp, false);
-            comp.gameObject.SetActive(false);
-            BuildUIBootstrap.EnsureForCurrentScene();
-            return;
-        }
-        IntroOverlayFallback.HideIfPresent();
+        var intro = UnityEngine.Object.FindObjectOfType<IntroMenuOverlay>(true);
+        if (intro != null) intro.gameObject.SetActive(false);
         BuildUIBootstrap.EnsureForCurrentScene();
     }
 

--- a/Assets/Scripts/Boot/BuildUIBootstrap.cs
+++ b/Assets/Scripts/Boot/BuildUIBootstrap.cs
@@ -29,10 +29,9 @@ public static class BuildUIBootstrap
 
     static bool IsIntroLike(string sceneName)
     {
-#if UNITY_EDITOR
-        UnityEngine.Debug.Log("[BuildUI] IsIntroLike disabled; relying on overlay visibility only.");
-#endif
-        return false;
+        if (string.IsNullOrEmpty(sceneName)) return false;
+        var s = sceneName.ToLowerInvariant();
+        return s.Contains("intro") || s.Contains("title");
     }
 
     static void EnsureEventSystem()


### PR DESCRIPTION
## Summary
- simplify intro visibility check and directly disable overlay instead of fading
- keep build HUD in scene names containing 'menu' by only checking 'intro' or 'title'

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ec83fc60832493c15b138f180c4f