### PR TITLE
Restructure project folders with readme scaffolding and asmdefs

### DIFF
--- a/Assets/Addressables/README.md
+++ b/Assets/Addressables/README.md
@@ -1,0 +1,6 @@
+# Addressables
+
+Groups and profiles for runtime content delivery (no Unity scenes).
+Keep atlases and large sprite groups here, organized by bucket (Characters, World, UI, VFX).
+
+Do not place code in this folder.

--- a/Assets/Art/PixelArt/Atlases/Characters/README.md
+++ b/Assets/Art/PixelArt/Atlases/Characters/README.md
@@ -1,0 +1,2 @@
+Packed character sheets for runtime.
+Built from Sources/Characters via importer.

--- a/Assets/Art/PixelArt/Atlases/UI/README.md
+++ b/Assets/Art/PixelArt/Atlases/UI/README.md
@@ -1,0 +1,2 @@
+UI atlases (icons, widgets, portraits). Consistent pixel grid.
+Built from Sources/UI.

--- a/Assets/Art/PixelArt/Atlases/VFX/README.md
+++ b/Assets/Art/PixelArt/Atlases/VFX/README.md
@@ -1,0 +1,2 @@
+VFX sprite sheets (weather, combat, environment).
+Keep sequences short; loop metadata in importer.

--- a/Assets/Art/PixelArt/Atlases/World/README.md
+++ b/Assets/Art/PixelArt/Atlases/World/README.md
@@ -1,0 +1,2 @@
+World tileset atlases (tiles, terrain edges).
+Autotile rules documented in Sources/World/Tilesets.

--- a/Assets/Art/PixelArt/Characters/Creatures/README.md
+++ b/Assets/Art/PixelArt/Characters/Creatures/README.md
@@ -1,0 +1,2 @@
+Creatures/animals/enemies. Keep per-species subfolders if needed.
+Document hitboxes if nonstandard.

--- a/Assets/Art/PixelArt/Characters/NPCs/README.md
+++ b/Assets/Art/PixelArt/Characters/NPCs/README.md
@@ -1,0 +1,2 @@
+NPC sprite sets (villagers, traders).
+Match player scale and pivots.

--- a/Assets/Art/PixelArt/Characters/Player/README.md
+++ b/Assets/Art/PixelArt/Characters/Player/README.md
@@ -1,0 +1,2 @@
+Player sprite sets (idle, walk, tools).
+Name by facing/state, sized @ native grid.

--- a/Assets/Art/PixelArt/Palettes/README.md
+++ b/Assets/Art/PixelArt/Palettes/README.md
@@ -1,0 +1,2 @@
+Global and per-bucket palettes (.gpl, .aseprite).
+Document usage and licensing.

--- a/Assets/Art/PixelArt/Sources/Characters/README.md
+++ b/Assets/Art/PixelArt/Sources/Characters/README.md
@@ -1,0 +1,2 @@
+Working files (.ase, .psd). Export via tools to Atlases/Characters.
+Keep tags/layers clean.

--- a/Assets/Art/PixelArt/Sources/UI/README.md
+++ b/Assets/Art/PixelArt/Sources/UI/README.md
@@ -1,0 +1,2 @@
+Working files for UI icons/widgets/portraits.
+Export via tools to Atlases/UI.

--- a/Assets/Art/PixelArt/Sources/VFX/README.md
+++ b/Assets/Art/PixelArt/Sources/VFX/README.md
@@ -1,0 +1,2 @@
+Working files for VFX.
+Export via tools to Atlases/VFX.

--- a/Assets/Art/PixelArt/Sources/World/README.md
+++ b/Assets/Art/PixelArt/Sources/World/README.md
@@ -1,0 +1,2 @@
+Working files for tilesets, terrain edges, props.
+Export via tools to Atlases/World.

--- a/Assets/Art/PixelArt/UI/Icons/README.md
+++ b/Assets/Art/PixelArt/UI/Icons/README.md
@@ -1,0 +1,2 @@
+Item/skill/status icons (16/24/32px consistent).
+Export sheets to Atlases/UI.

--- a/Assets/Art/PixelArt/UI/Portraits/README.md
+++ b/Assets/Art/PixelArt/UI/Portraits/README.md
@@ -1,0 +1,2 @@
+Pawn portraits/expressions. Keep palette refs in Palettes/.
+Consistent framing.

--- a/Assets/Art/PixelArt/UI/Widgets/README.md
+++ b/Assets/Art/PixelArt/UI/Widgets/README.md
@@ -1,0 +1,2 @@
+UI elements (frames, panels, buttons, cursors).
+Slice for 9-slice where applicable.

--- a/Assets/Art/PixelArt/VFX/Combat/README.md
+++ b/Assets/Art/PixelArt/VFX/Combat/README.md
@@ -1,0 +1,2 @@
+Combat effects (slashes, impacts, projectiles).
+Short loops preferred.

--- a/Assets/Art/PixelArt/VFX/Environment/README.md
+++ b/Assets/Art/PixelArt/VFX/Environment/README.md
@@ -1,0 +1,2 @@
+Ambient effects (dust, leaves, water ripples).
+Tie into weather/time-of-day later.

--- a/Assets/Art/PixelArt/VFX/Weather/README.md
+++ b/Assets/Art/PixelArt/VFX/Weather/README.md
@@ -1,0 +1,2 @@
+Weather sprites (rain, snow, storms).
+Keep per-intensity variants if needed.

--- a/Assets/Art/PixelArt/World/Buildings/README.md
+++ b/Assets/Art/PixelArt/World/Buildings/README.md
@@ -1,0 +1,2 @@
+Constructed structures (walls, roofs). Separate masks if used.
+Export to Atlases/World.

--- a/Assets/Art/PixelArt/World/Overworld/README.md
+++ b/Assets/Art/PixelArt/World/Overworld/README.md
@@ -1,0 +1,2 @@
+Overworld icons/markers (world remains hidden; icons used in UI/legend).
+Export to Atlases/UI or Atlases/World as needed.

--- a/Assets/Art/PixelArt/World/Props/README.md
+++ b/Assets/Art/PixelArt/World/Props/README.md
@@ -1,0 +1,2 @@
+Trees, rocks, decor. Keep by biome or theme if needed.
+Export to Atlases/World.

--- a/Assets/Art/PixelArt/World/Terrain/README.md
+++ b/Assets/Art/PixelArt/World/Terrain/README.md
@@ -1,0 +1,2 @@
+Cliffs, water edges, transitions. Autotile references here.
+Export to Atlases/World.

--- a/Assets/Art/PixelArt/World/Tilesets/README.md
+++ b/Assets/Art/PixelArt/World/Tilesets/README.md
@@ -1,0 +1,2 @@
+Ground/terrain tilesets at native grid (16/32px).
+Export to Atlases/World.

--- a/Assets/Art/PixelArt/_Guidelines/README.md
+++ b/Assets/Art/PixelArt/_Guidelines/README.md
@@ -1,0 +1,9 @@
+# Pixel Art Guidelines
+- Native grid size (e.g., 16px or 32px)
+- Pivot rules: feet (characters), center (items), bottom (buildings)
+- Aseprite tag → Sprite slice naming
+- Palette usage and file format (.gpl)
+- Export flow: Sources → Atlases (per bucket)
+- Addressables groups per bucket (Characters, World, UI, VFX)
+- Naming: [category_subject_variant_state@px.png](mailto:category_subject_variant_state@px.png)
+- No scenes.

--- a/Assets/Audio/Music/README.md
+++ b/Assets/Audio/Music/README.md
@@ -1,0 +1,1 @@
+Music tracks (OGG/WAV). One subfolder per album/area.

--- a/Assets/Audio/SFX/README.md
+++ b/Assets/Audio/SFX/README.md
@@ -1,0 +1,2 @@
+SFX organized by category (UI, Combat, Environment).
+Prefer short, dry samples; loop points via import settings.

--- a/Assets/Audio/UI/README.md
+++ b/Assets/Audio/UI/README.md
@@ -1,0 +1,1 @@
+UI click/hover/notification sounds.

--- a/Assets/Defs/Buildings/Furniture/README.md
+++ b/Assets/Defs/Buildings/Furniture/README.md
@@ -1,0 +1,1 @@
+Furniture defs (beds, chairs, tables).

--- a/Assets/Defs/Buildings/Storage/README.md
+++ b/Assets/Defs/Buildings/Storage/README.md
@@ -1,0 +1,1 @@
+Stockpiles, containers, and capacity rules.

--- a/Assets/Defs/Buildings/Workbenches/README.md
+++ b/Assets/Defs/Buildings/Workbenches/README.md
@@ -1,0 +1,1 @@
+Production buildings and their recipes.

--- a/Assets/Defs/Core/GameRules/README.md
+++ b/Assets/Defs/Core/GameRules/README.md
@@ -1,0 +1,2 @@
+Core game rule XML (turn lengths, caps, constants).
+Small files by topic.

--- a/Assets/Defs/Core/Stats/README.md
+++ b/Assets/Defs/Core/Stats/README.md
@@ -1,0 +1,2 @@
+Stat defs and curves. Split by system (combat, economy, needs).
+One concept per file.

--- a/Assets/Defs/Core/Tags/README.md
+++ b/Assets/Defs/Core/Tags/README.md
@@ -1,0 +1,1 @@
+Shared tag/category defs used across items, pawns, buildings.

--- a/Assets/Defs/Incidents/README.md
+++ b/Assets/Defs/Incidents/README.md
@@ -1,0 +1,1 @@
+Random incidents/events tuning.

--- a/Assets/Defs/Items/Apparel/README.md
+++ b/Assets/Defs/Items/Apparel/README.md
@@ -1,0 +1,1 @@
+Apparel/armor and insulation stats.

--- a/Assets/Defs/Items/Materials/README.md
+++ b/Assets/Defs/Items/Materials/README.md
@@ -1,0 +1,1 @@
+Base materials and properties.

--- a/Assets/Defs/Items/Weapons/README.md
+++ b/Assets/Defs/Items/Weapons/README.md
@@ -1,0 +1,1 @@
+Weapons by class (melee/ranged). Balance by tier.

--- a/Assets/Defs/Pawns/Backstories/README.md
+++ b/Assets/Defs/Pawns/Backstories/README.md
@@ -1,0 +1,1 @@
+Pawn backstories & roll tables.

--- a/Assets/Defs/Pawns/Needs/README.md
+++ b/Assets/Defs/Pawns/Needs/README.md
@@ -1,0 +1,1 @@
+Needs defs (hunger, rest, mood). Tuned per cadence.

--- a/Assets/Defs/Pawns/Races/README.md
+++ b/Assets/Defs/Pawns/Races/README.md
@@ -1,0 +1,1 @@
+Playable/NPC races/species.

--- a/Assets/Defs/Pawns/Traits/README.md
+++ b/Assets/Defs/Pawns/Traits/README.md
@@ -1,0 +1,1 @@
+Trait pools by theme (social, combat, survival).

--- a/Assets/Defs/Quests/README.md
+++ b/Assets/Defs/Quests/README.md
@@ -1,0 +1,1 @@
+Quest templates and flows.

--- a/Assets/Defs/README.md
+++ b/Assets/Defs/README.md
@@ -1,0 +1,9 @@
+# XML Defs (Base Game)
+
+Modder-friendly grouping. Load order at AppBoot:
+1) Base (this folder)
+2) Bundled Mods (StreamingAssets/Mods/*)
+3) User Mods (%USER%/FantasyColony/Mods/*)
+
+Mirrors the folder layout used in Mods.
+Validate against Tools/Schema/defs.xsd in CI/dev builds.

--- a/Assets/Defs/Recipes/README.md
+++ b/Assets/Defs/Recipes/README.md
@@ -1,0 +1,1 @@
+Crafting/processing recipes.

--- a/Assets/Defs/Research/README.md
+++ b/Assets/Defs/Research/README.md
@@ -1,0 +1,1 @@
+Research tree and unlocks.

--- a/Assets/Defs/UI/README.md
+++ b/Assets/Defs/UI/README.md
@@ -1,0 +1,1 @@
+UI-related defs (colors, styles, icon catalogs).

--- a/Assets/Defs/World/Biomes/README.md
+++ b/Assets/Defs/World/Biomes/README.md
@@ -1,0 +1,2 @@
+Biome defs (temperature/precipitation, flora/fauna tables).
+Used by MapGen and Overworld.

--- a/Assets/Defs/World/Factions/README.md
+++ b/Assets/Defs/World/Factions/README.md
@@ -1,0 +1,2 @@
+Faction templates/relations. Overridden by mods for total conversions.
+Keep diplomatic defaults readable.

--- a/Assets/Defs/World/Sites/README.md
+++ b/Assets/Defs/World/Sites/README.md
@@ -1,0 +1,1 @@
+Overworld site types (ruins, camps, towns) and spawn rules.

--- a/Assets/Defs/World/WorldTags/README.md
+++ b/Assets/Defs/World/WorldTags/README.md
@@ -1,0 +1,1 @@
+Global world tags that affect events/encounters.

--- a/Assets/Editor/FantasyColony.Editor.asmdef
+++ b/Assets/Editor/FantasyColony.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+  "name": "FantasyColony.Editor",
+  "references": [
+    "FantasyColony.Core",
+    "FantasyColony.World",
+    "FantasyColony.Gameplay",
+    "FantasyColony.UI"
+  ],
+  "includePlatforms": ["Editor"],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Assets/Editor/README.md
+++ b/Assets/Editor/README.md
@@ -1,0 +1,1 @@
+Editor-only scripts (importers, inspectors, tools).

--- a/Assets/Fonts/README.md
+++ b/Assets/Fonts/README.md
@@ -1,0 +1,2 @@
+Runtime fonts and TMP assets.
+Place fallback/CJK fonts in subfolders as needed.

--- a/Assets/Localization/Fonts/README.md
+++ b/Assets/Localization/Fonts/README.md
@@ -1,0 +1,1 @@
+Locale-specific font assets.

--- a/Assets/Localization/StringTables/README.md
+++ b/Assets/Localization/StringTables/README.md
@@ -1,0 +1,2 @@
+Localization string tables.
+Naming: UI_Common, Items_Weapons, etc.

--- a/Assets/Materials/README.md
+++ b/Assets/Materials/README.md
@@ -1,0 +1,1 @@
+Shared materials for sprites/VFX.

--- a/Assets/Prefabs/Buildings/README.md
+++ b/Assets/Prefabs/Buildings/README.md
@@ -1,0 +1,2 @@
+Place building prefabs here. Keep per-type subfolders optional.
+Link to Defs/Buildings counterparts via GUID.

--- a/Assets/Prefabs/Camera/README.md
+++ b/Assets/Prefabs/Camera/README.md
@@ -1,0 +1,1 @@
+Camera rigs and helpers.

--- a/Assets/Prefabs/Characters/README.md
+++ b/Assets/Prefabs/Characters/README.md
@@ -1,0 +1,1 @@
+Character prefab roots (no scene usage).

--- a/Assets/Prefabs/Items/README.md
+++ b/Assets/Prefabs/Items/README.md
@@ -1,0 +1,1 @@
+Item prefab roots and pickup visuals.

--- a/Assets/Prefabs/Pawns/README.md
+++ b/Assets/Prefabs/Pawns/README.md
@@ -1,0 +1,1 @@
+Pawn prefab roots (controllers, sprite links).

--- a/Assets/Prefabs/Props/README.md
+++ b/Assets/Prefabs/Props/README.md
@@ -1,0 +1,1 @@
+World props and decor prefabs.

--- a/Assets/Prefabs/UI/README.md
+++ b/Assets/Prefabs/UI/README.md
@@ -1,0 +1,1 @@
+UI prefabs (windows, controls).

--- a/Assets/Prefabs/VFX/README.md
+++ b/Assets/Prefabs/VFX/README.md
@@ -1,0 +1,1 @@
+Visual effects prefabs (weather, particles, overlays).

--- a/Assets/Scripts/Core/Config/README.md
+++ b/Assets/Scripts/Core/Config/README.md
@@ -1,0 +1,2 @@
+Startup config, feature flags, content paths.
+No scene logic.

--- a/Assets/Scripts/Core/Diagnostics/README.md
+++ b/Assets/Scripts/Core/Diagnostics/README.md
@@ -1,0 +1,1 @@
+Logging, profiling, lifecycle reports.

--- a/Assets/Scripts/Core/Events/README.md
+++ b/Assets/Scripts/Core/Events/README.md
@@ -1,0 +1,2 @@
+(Later) Domain events bus and attributes.
+Keep independent from Stage lifecycle.

--- a/Assets/Scripts/Core/FantasyColony.Core.asmdef
+++ b/Assets/Scripts/Core/FantasyColony.Core.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "FantasyColony.Core",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Assets/Scripts/Core/SaveLoad/README.md
+++ b/Assets/Scripts/Core/SaveLoad/README.md
@@ -1,0 +1,1 @@
+Save system, serializer, versioning, safe writes.

--- a/Assets/Scripts/Dev/Cheats/README.md
+++ b/Assets/Scripts/Dev/Cheats/README.md
@@ -1,0 +1,1 @@
+Development cheats/console commands (Editor-only assembly).

--- a/Assets/Scripts/Dev/Debug/README.md
+++ b/Assets/Scripts/Dev/Debug/README.md
@@ -1,0 +1,2 @@
+Debug helpers, gizmos, test hooks.
+Exclude from builds as needed.

--- a/Assets/Scripts/Dev/FantasyColony.Dev.asmdef
+++ b/Assets/Scripts/Dev/FantasyColony.Dev.asmdef
@@ -1,0 +1,18 @@
+{
+  "name": "FantasyColony.Dev",
+  "references": [
+    "FantasyColony.Core",
+    "FantasyColony.World",
+    "FantasyColony.Gameplay",
+    "FantasyColony.UI"
+  ],
+  "includePlatforms": ["Editor"],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Assets/Scripts/Gameplay/Camera/README.md
+++ b/Assets/Scripts/Gameplay/Camera/README.md
@@ -1,0 +1,2 @@
+Camera rig, framing, follow logic (scene-free).
+Stage-gated at Gameplay.

--- a/Assets/Scripts/Gameplay/FantasyColony.Gameplay.asmdef
+++ b/Assets/Scripts/Gameplay/FantasyColony.Gameplay.asmdef
@@ -1,0 +1,16 @@
+{
+  "name": "FantasyColony.Gameplay",
+  "references": [
+    "FantasyColony.Core",
+    "FantasyColony.World"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Assets/Scripts/Gameplay/Items/README.md
+++ b/Assets/Scripts/Gameplay/Items/README.md
@@ -1,0 +1,1 @@
+Runtime item logic (pickup, stack, quality).

--- a/Assets/Scripts/Gameplay/Pawns/README.md
+++ b/Assets/Scripts/Gameplay/Pawns/README.md
@@ -1,0 +1,2 @@
+Pawn runtime logic, controllers, spawn manager.
+Emits PawnSpawned domain events (later).

--- a/Assets/Scripts/Gameplay/Systems/AI/README.md
+++ b/Assets/Scripts/Gameplay/Systems/AI/README.md
@@ -1,0 +1,1 @@
+AI planners/behaviours.

--- a/Assets/Scripts/Gameplay/Systems/Director/README.md
+++ b/Assets/Scripts/Gameplay/Systems/Director/README.md
@@ -1,0 +1,2 @@
+Evaluates world state every 6 in-game hours and on region entry (ADR-0002).
+Subscribes to cadence ticks and domain events.

--- a/Assets/Scripts/Gameplay/Systems/Economy/README.md
+++ b/Assets/Scripts/Gameplay/Systems/Economy/README.md
@@ -1,0 +1,1 @@
+Production, trade, pricing logic.

--- a/Assets/Scripts/Gameplay/Systems/Inventory/README.md
+++ b/Assets/Scripts/Gameplay/Systems/Inventory/README.md
@@ -1,0 +1,1 @@
+Inventories, containers, transfers.

--- a/Assets/Scripts/Gameplay/Systems/Jobs/README.md
+++ b/Assets/Scripts/Gameplay/Systems/Jobs/README.md
@@ -1,0 +1,1 @@
+Job system, work priorities.

--- a/Assets/Scripts/Gameplay/Systems/Needs/README.md
+++ b/Assets/Scripts/Gameplay/Systems/Needs/README.md
@@ -1,0 +1,1 @@
+Needs tickers; cadence-driven updates.

--- a/Assets/Scripts/UI/Common/README.md
+++ b/Assets/Scripts/UI/Common/README.md
@@ -1,0 +1,1 @@
+Reusable UI widgets and utilities.

--- a/Assets/Scripts/UI/EmbarkPrep/README.md
+++ b/Assets/Scripts/UI/EmbarkPrep/README.md
@@ -1,0 +1,2 @@
+UI to pick starting pawn and biome/region.
+Advances to MapGen stage.

--- a/Assets/Scripts/UI/FantasyColony.UI.asmdef
+++ b/Assets/Scripts/UI/FantasyColony.UI.asmdef
@@ -1,0 +1,17 @@
+{
+  "name": "FantasyColony.UI",
+  "references": [
+    "FantasyColony.Core",
+    "FantasyColony.World",
+    "FantasyColony.Gameplay"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Assets/Scripts/UI/HUD/README.md
+++ b/Assets/Scripts/UI/HUD/README.md
@@ -1,0 +1,2 @@
+Gameplay HUD (toolbars, overlays). Stage-driven show/hide.
+No intro visibility blockers.

--- a/Assets/Scripts/UI/Intro/README.md
+++ b/Assets/Scripts/UI/Intro/README.md
@@ -1,0 +1,2 @@
+Intro screen and shell. Start → WorldSetup.
+No scene dependencies.

--- a/Assets/Scripts/UI/WorldSetup/README.md
+++ b/Assets/Scripts/UI/WorldSetup/README.md
@@ -1,0 +1,2 @@
+World generation selections (seed, difficulty, knobs).
+Generate → WorldSim.

--- a/Assets/Scripts/World/FantasyColony.World.asmdef
+++ b/Assets/Scripts/World/FantasyColony.World.asmdef
@@ -1,0 +1,15 @@
+{
+  "name": "FantasyColony.World",
+  "references": [
+    "FantasyColony.Core"
+  ],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Assets/Scripts/World/FogOfWar/README.md
+++ b/Assets/Scripts/World/FogOfWar/README.md
@@ -1,0 +1,2 @@
+Discovery state and reveal logic. World stays hidden until explored.
+Emits MapEntered events (later).

--- a/Assets/Scripts/World/MapGen/README.md
+++ b/Assets/Scripts/World/MapGen/README.md
@@ -1,0 +1,2 @@
+Map grid generation for chosen biome; spawns starting pawn.
+Creates GameClock at MapGen (ticking starts at Gameplay).

--- a/Assets/Scripts/World/Regions/README.md
+++ b/Assets/Scripts/World/Regions/README.md
@@ -1,0 +1,2 @@
+Region data and connectivity. Used by exploration and Director.
+No scene refs.

--- a/Assets/Scripts/World/WorldSim/README.md
+++ b/Assets/Scripts/World/WorldSim/README.md
@@ -1,0 +1,2 @@
+Generates hidden overworld state (factions, sites, world tags, routes).
+Feeds EmbarkPrep.

--- a/Assets/Shaders/README.md
+++ b/Assets/Shaders/README.md
@@ -1,0 +1,2 @@
+Sprite/2D shaders and shader graphs.
+Document render pipeline compatibility here.

--- a/Mods/_TemplateMod/Art/PixelArt/Atlases/README.md
+++ b/Mods/_TemplateMod/Art/PixelArt/Atlases/README.md
@@ -1,0 +1,2 @@
+Packed sprite sheets used by the mod.
+Keep consistent with base buckets (Characters, World, UI, VFX).

--- a/Mods/_TemplateMod/Art/PixelArt/Sources/README.md
+++ b/Mods/_TemplateMod/Art/PixelArt/Sources/README.md
@@ -1,0 +1,2 @@
+Working files (.ase/.psd).
+Export atlases to Mods/_TemplateMod/Art/PixelArt/Atlases.

--- a/Mods/_TemplateMod/Defs/README.md
+++ b/Mods/_TemplateMod/Defs/README.md
@@ -1,0 +1,3 @@
+Put your XML here, mirroring Assets/Defs categories.
+Example: Items/Weapons/MyWeapons.xml
+Small files, clear ids.

--- a/Mods/_TemplateMod/README.md
+++ b/Mods/_TemplateMod/README.md
@@ -1,0 +1,6 @@
+# Template Mod
+
+Mirror the base game's folder structure. Put XML in `Defs/` using the same categories.
+Place pixel art in `Art/PixelArt` using the same buckets (Characters, World, UI, VFX).
+
+The loader searches Mods/<ModId>/Defs first by dependency graph, then by name.

--- a/Mods/_TemplateMod/modinfo.json
+++ b/Mods/_TemplateMod/modinfo.json
@@ -1,0 +1,10 @@
+{
+  "id": "example.mod.template",
+  "name": "Example Template Mod",
+  "version": "1.0.0",
+  "author": "YourName",
+  "description": "Template showing folder layout and defs grouping.",
+  "dependencies": [],
+  "loadBefore": [],
+  "loadAfter": []
+}

--- a/Tests/EditMode/FantasyColony.Tests.EditMode.asmdef
+++ b/Tests/EditMode/FantasyColony.Tests.EditMode.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "FantasyColony.Tests.EditMode",
+  "references": [
+    "FantasyColony.Core",
+    "FantasyColony.World",
+    "FantasyColony.Gameplay",
+    "FantasyColony.UI"
+  ],
+  "includePlatforms": ["Editor"],
+  "optionalUnityReferences": ["TestAssemblies"],
+  "autoReferenced": false,
+  "noEngineReferences": false
+}

--- a/Tests/EditMode/README.md
+++ b/Tests/EditMode/README.md
@@ -1,0 +1,2 @@
+EditMode tests (pure C#/editor-only).
+Use TestRunner categories.

--- a/Tests/PlayMode/FantasyColony.Tests.PlayMode.asmdef
+++ b/Tests/PlayMode/FantasyColony.Tests.PlayMode.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "FantasyColony.Tests.PlayMode",
+  "references": [
+    "FantasyColony.Core",
+    "FantasyColony.World",
+    "FantasyColony.Gameplay",
+    "FantasyColony.UI"
+  ],
+  "includePlatforms": ["Editor"],
+  "optionalUnityReferences": ["TestAssemblies"],
+  "autoReferenced": false,
+  "noEngineReferences": false
+}

--- a/Tests/PlayMode/README.md
+++ b/Tests/PlayMode/README.md
@@ -1,0 +1,2 @@
+PlayMode tests (runtime-style). No scenes; bootstrap with StageRunner.
+Avoid timing flakes.

--- a/Tools/Build/README.md
+++ b/Tools/Build/README.md
@@ -1,0 +1,2 @@
+Build/publish scripts and configs.
+No game code here.

--- a/Tools/Importers/README.md
+++ b/Tools/Importers/README.md
@@ -1,0 +1,2 @@
+Aseprite exporters, atlas builders, and slice/pivot utilities.
+Run from Editor menu or CI.

--- a/Tools/Schema/README.md
+++ b/Tools/Schema/README.md
@@ -1,0 +1,3 @@
+Place XML schemas here (defs.xsd).
+CI validates Assets/Defs/** and Mods/*/Defs/** against these.
+Dev builds log validation warnings.


### PR DESCRIPTION
## Summary
- Organize Defs by domain and document load order for modding
- Add pixel art buckets with guidelines and addressable structure
- Introduce core/gameplay/world/UI assembly definitions and mod/test templates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b30498fb548324a1aa80481731dd5c