### PR TITLE
CI: stage root and Docs indexes for commit

### DIFF
--- a/.github/workflows/regenerate-indexes.yml
+++ b/.github/workflows/regenerate-indexes.yml
@@ -116,6 +116,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git add CODE_SNAPSHOT.txt CODE_INDEX.md SYMBOLS.json 2>/dev/null || true
+          git add INDEX.md Docs/INDEX.md 2>/dev/null || true
           git add XML_INDEX.md XML_SNAPSHOT.txt 2>/dev/null || true
           git add Docs/Templates/Defs/ 2>/dev/null || true
           git add Docs/XML_ARTIFACTS.md 2>/dev/null || true


### PR DESCRIPTION
## Summary
- ensure workflow also stages root `INDEX.md` and `Docs/INDEX.md` when committing regenerated indexes

## Testing
- `yamllint .github/workflows/regenerate-indexes.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38dbe230883249029d37844a8e508