### PR TITLE
CI: limit unified workflow to run only on pushes to main (post-merge)

### DIFF
--- a/.github/workflows/regenerate-indexes.yml
+++ b/.github/workflows/regenerate-indexes.yml
@@ -2,6 +2,8 @@ name: Regenerate & commit indexes/snapshots (unified)
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Restrict indexes/snapshots workflow to run only on pushes to `main`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38f0f28ec8324af733c46f436ed5b