### PR TITLE
ci: regenerate indexes workflow adds root and docs index regeneration

### DIFF
--- a/.github/workflows/regenerate-indexes.yml
+++ b/.github/workflows/regenerate-indexes.yml
@@ -3,8 +3,8 @@ name: Regenerate & commit indexes/snapshots (unified)
 on:
   push:
     branches:
-      - main
-  workflow_dispatch:
+      - main          # run only after merges/direct pushes to main
+  workflow_dispatch:   # allow manual runs
 
 permissions:
   contents: write
@@ -18,6 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      # --- XML: run your generator if present (writes under Docs/Templates/Defs/** and root XML_* files) ---
       - name: Setup .NET (for XML tools)
         if: ${{ hashFiles('Tools/**/*.csproj') != '' }}
         uses: actions/setup-dotnet@v4
@@ -32,16 +33,23 @@ jobs:
             dotnet run --project Tools/XmlDefsTools/XmlDefsTools.csproj || true
           fi
 
+      # --- CODE: regenerate CODE_SNAPSHOT.txt, CODE_INDEX.md, SYMBOLS.json from tracked .cs files ---
       - name: Regenerate code snapshot, index, and symbols
         shell: bash
         run: |
           set -euo pipefail
+
           REPO="${GITHUB_REPOSITORY}"
           REF_NAME="${GITHUB_REF_NAME:-${GITHUB_HEAD_REF:-${GITHUB_REF##*/}}}"
           NOW="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
 
-          mapfile -t CS_FILES < <(git ls-files | grep -E '\.cs$' | grep -Ev '^(Library|Temp|Build|obj|\.git)/' | sort)
+          # Collect tracked C# files deterministically
+          mapfile -t CS_FILES < <(git ls-files \
+            | grep -E '\.cs$' \
+            | grep -Ev '^(Library|Temp|Build|obj|\.git)/' \
+            | sort)
 
+          #### CODE_SNAPSHOT.txt ####
           {
             echo "# Auto-generated code snapshot"
             echo "_Updated_: ${NOW}"
@@ -53,6 +61,7 @@ jobs:
             done
           } > CODE_SNAPSHOT.txt
 
+          #### CODE_INDEX.md ####
           {
             echo "# Code Index"
             echo
@@ -65,30 +74,34 @@ jobs:
             done
           } > CODE_INDEX.md
 
+          #### SYMBOLS.json (awk with safe quoting — no backslash escapes in literals) ####
           tmp_symbols="$(mktemp)"
           echo '{ "files": [' > "${tmp_symbols}"
           first_file=1
           for f in "${CS_FILES[@]}"; do
             json="$(awk -v file="$f" '
               BEGIN {
-                q = sprintf("%c",34)
+                q = sprintf("%c",34)   # double-quote
                 ns=""; type=""; firstSym=1
                 printf("{ " q "file" q ": " q file q ", " q "symbols" q ": [")
               }
               {
                 line=NR
+                # namespace
                 if ($0 ~ /^[ \t]*namespace[ \t]+[A-Za-z_][A-Za-z0-9_.]*/) {
                   match($0, /namespace[ \t]+([A-Za-z_][A-Za-z0-9_.]*)/, m)
                   ns=m[1]
                   obj="{" q "kind" q ":" q "namespace" q "," q "name" q ":" q ns q "," q "line" q ":" line "}"
                   printf(firstSym ? obj : "," obj); firstSym=0
                 }
+                # type: class/struct/interface/enum
                 if ($0 ~ /^[ \t]*(public|internal|protected|private)?[ \t]*(sealed|abstract|static)?[ \t]*(class|struct|interface|enum)[ \t]+[A-Za-z_][A-Za-z0-9_]*/) {
                   match($0, /(class|struct|interface|enum)[ \t]+([A-Za-z_][A-Za-z0-9_]*)/, t)
                   kind=t[1]; type=t[2]
                   obj="{" q "kind" q ":" q kind q "," q "name" q ":" q type q "," q "namespace" q ":" q ns q "," q "line" q ":" line "}"
                   printf(firstSym ? obj : "," obj); firstSym=0
                 }
+                # methods (best-effort): access? static? return? Name( ... ) {
                 if ($0 ~ /^[ \t]*(public|private|protected|internal)[^;{=]*\([^\)]*\)[ \t]*\{/ ) {
                   match($0, /([A-Za-z_][A-Za-z0-9_]*)[ \t]*\(/, m)
                   if (m[1] != "") {
@@ -110,17 +123,59 @@ jobs:
           echo '] }' >> "${tmp_symbols}"
           mv "${tmp_symbols}" SYMBOLS.json
 
+      # --- INDEX pages: regenerate root and Docs indexes so they can be committed if changed ---
+      - name: Regenerate root and docs indexes
+        shell: bash
+        run: |
+          set -euo pipefail
+          NOW="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+
+          # Root INDEX.md
+          {
+            echo "# Repository Index"
+            echo
+            echo "_Updated_: ${NOW}"
+            echo
+            echo "## Summary"
+            total_files="$(git ls-files | wc -l | tr -d ' ')"
+            cs_count="$(git ls-files | grep -E '\.cs$' | wc -l | tr -d ' ')"
+            echo "- Tracked files: ${total_files}"
+            echo "- C# files: ${cs_count}"
+            echo
+            echo "## Top-level"
+            for d in $(git ls-files | awk -F/ '{print $1}' | sort -u); do
+              if [ -d "$d" ]; then
+                count=$(git ls-files "$d" | wc -l | tr -d ' ')
+                echo "- \`$d\` (${count} files)"
+              fi
+            done
+          } > INDEX.md
+
+          # Docs/INDEX.md
+          mkdir -p Docs
+          if git ls-files Docs >/dev/null 2>&1; then
+            git ls-files Docs | sed 's/^/- `&`/' > Docs/INDEX.md
+          else
+            echo "_No Docs folder found_" > Docs/INDEX.md
+          fi
+
+      # --- COMMIT: stage known outputs and commit only if staged diff exists ---
       - name: Commit regenerated files if changed
         shell: bash
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
+          git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # Stage code artifacts
           git add CODE_SNAPSHOT.txt CODE_INDEX.md SYMBOLS.json 2>/dev/null || true
+          # Stage root and docs indexes
           git add INDEX.md Docs/INDEX.md 2>/dev/null || true
+          # Stage XML root artifacts expected by live links
           git add XML_INDEX.md XML_SNAPSHOT.txt 2>/dev/null || true
+          # Stage XML samples/schemas where live links point
           git add Docs/Templates/Defs/ 2>/dev/null || true
+          # Optional: any XML artifact summary your tool emits
           git add Docs/XML_ARTIFACTS.md 2>/dev/null || true
 
           if ! git diff --cached --quiet --exit-code; then


### PR DESCRIPTION
## Summary
- expand Regenerate & commit indexes/snapshots workflow to rebuild INDEX.md and Docs/INDEX.md

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository unsigned)*

------
https://chatgpt.com/codex/tasks/task_e_68b394dd3ab08324972fee5ecbfbf29c