### PR TITLE
Add runtime bootstrap and basic main menu UI

### DIFF
--- a/Assets/Scripts/Core.meta
+++ b/Assets/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f14053bea4b4c8b99c1057745c3017c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/AppBootstrap.cs
+++ b/Assets/Scripts/Core/AppBootstrap.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace FantasyColony.Core
+{
+    /// <summary>
+    /// Single entry point. We don't rely on authored Unity scenes; everything is spawned at runtime.
+    /// </summary>
+    public static class AppBootstrap
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Boot()
+        {
+            // Root host object that survives for the whole app lifetime.
+            var root = new GameObject("AppRoot");
+            Object.DontDestroyOnLoad(root);
+            root.AddComponent<AppHost>();
+        }
+    }
+}

--- a/Assets/Scripts/Core/AppBootstrap.cs.meta
+++ b/Assets/Scripts/Core/AppBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8cdd8c2417794af2b8329b274f0adffa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/AppHost.cs
+++ b/Assets/Scripts/Core/AppHost.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using FantasyColony.UI.Root;
+using FantasyColony.UI.Router;
+using FantasyColony.Core.Services;
+
+namespace FantasyColony.Core
+{
+    /// <summary>
+    /// Lifetime owner. Builds services, creates UIRoot and pushes Main Menu screen.
+    /// </summary>
+    public class AppHost : MonoBehaviour
+    {
+        private ServiceRegistry _services;
+        private UIRoot _uiRoot;
+        private UIRouter _router;
+
+        private void Awake()
+        {
+            Application.targetFrameRate = 60;
+            QualitySettings.vSyncCount = 0;
+
+            _services = new ServiceRegistry();
+            _services.Register<ILogger>(new FileLogger());
+            _services.Register<IConfigService>(new DummyConfigService());
+            _services.Register<IEventBus>(new SimpleEventBus());
+            _services.Register<IAssetProvider>(new ResourcesAssetProvider());
+
+            // Create UI root (Canvas + EventSystem)
+            _uiRoot = UIRoot.Create(transform);
+
+            // Router mounts screens under UIRoot
+            _router = new UIRouter(_uiRoot.ScreenParent, _services);
+
+            // Push Main Menu
+            _router.Push<FantasyColony.UI.Screens.MainMenuScreen>();
+        }
+    }
+}

--- a/Assets/Scripts/Core/AppHost.cs.meta
+++ b/Assets/Scripts/Core/AppHost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5300ba81801f49da9c1c700935b62f10
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/ServiceRegistry.cs
+++ b/Assets/Scripts/Core/ServiceRegistry.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace FantasyColony.Core
+{
+    public sealed class ServiceRegistry
+    {
+        private readonly Dictionary<Type, object> _map = new();
+
+        public void Register<T>(T impl) where T : class
+        {
+            _map[typeof(T)] = impl ?? throw new ArgumentNullException(nameof(impl));
+        }
+
+        public T Get<T>() where T : class
+        {
+            if (_map.TryGetValue(typeof(T), out var o) && o is T t)
+                return t;
+            throw new InvalidOperationException($"Service not registered: {typeof(T).Name}");
+        }
+    }
+}

--- a/Assets/Scripts/Core/ServiceRegistry.cs.meta
+++ b/Assets/Scripts/Core/ServiceRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b526a6dbe7b0472d8341e441de21856f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Services.meta
+++ b/Assets/Scripts/Core/Services.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52dc11086f4e49b58e33035b232ee654
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Services/IAssetProvider.cs
+++ b/Assets/Scripts/Core/Services/IAssetProvider.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace FantasyColony.Core.Services
+{
+    public interface IAssetProvider
+    {
+        Sprite LoadSprite(string virtualPath);
+        AudioClip LoadAudio(string virtualPath);
+    }
+
+    public sealed class ResourcesAssetProvider : IAssetProvider
+    {
+        public Sprite LoadSprite(string virtualPath)
+        {
+            return Resources.Load<Sprite>(virtualPath);
+        }
+
+        public AudioClip LoadAudio(string virtualPath)
+        {
+            return Resources.Load<AudioClip>(virtualPath);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Services/IAssetProvider.cs.meta
+++ b/Assets/Scripts/Core/Services/IAssetProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0196564f48bc44e2ab325edaa4191ba5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Services/IConfigService.cs
+++ b/Assets/Scripts/Core/Services/IConfigService.cs
@@ -1,0 +1,19 @@
+namespace FantasyColony.Core.Services
+{
+    public interface IConfigService
+    {
+        string Get(string key, string fallback = "");
+        void Set(string key, string value);
+        void Save();
+    }
+
+    /// <summary>
+    /// Minimal no-op config for early boot. Replace later with a JSON-backed service.
+    /// </summary>
+    public sealed class DummyConfigService : IConfigService
+    {
+        public string Get(string key, string fallback = "") => fallback;
+        public void Set(string key, string value) { }
+        public void Save() { }
+    }
+}

--- a/Assets/Scripts/Core/Services/IConfigService.cs.meta
+++ b/Assets/Scripts/Core/Services/IConfigService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6050b6d185254afa86982a973d67665b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Services/IEventBus.cs
+++ b/Assets/Scripts/Core/Services/IEventBus.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace FantasyColony.Core.Services
+{
+    public interface IEventBus
+    {
+        void Subscribe<T>(Action<T> handler);
+        void Unsubscribe<T>(Action<T> handler);
+        void Publish<T>(T evt);
+    }
+
+    public sealed class SimpleEventBus : IEventBus
+    {
+        private readonly Dictionary<Type, Delegate> _subs = new();
+
+        public void Subscribe<T>(Action<T> handler)
+        {
+            if (_subs.TryGetValue(typeof(T), out var d))
+                _subs[typeof(T)] = Delegate.Combine(d, handler);
+            else
+                _subs[typeof(T)] = handler;
+        }
+
+        public void Unsubscribe<T>(Action<T> handler)
+        {
+            if (_subs.TryGetValue(typeof(T), out var d))
+            {
+                var res = Delegate.Remove(d, handler);
+                if (res == null) _subs.Remove(typeof(T));
+                else _subs[typeof(T)] = res;
+            }
+        }
+
+        public void Publish<T>(T evt)
+        {
+            if (_subs.TryGetValue(typeof(T), out var d) && d is Action<T> a)
+            {
+                a.Invoke(evt);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Services/IEventBus.cs.meta
+++ b/Assets/Scripts/Core/Services/IEventBus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe43eaa0148242faaa3aa26f73f1aa84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Services/ILogger.cs
+++ b/Assets/Scripts/Core/Services/ILogger.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace FantasyColony.Core.Services
+{
+    public interface ILogger
+    {
+        void Info(string msg);
+        void Warn(string msg);
+        void Error(string msg, Exception ex = null);
+    }
+
+    public sealed class FileLogger : ILogger
+    {
+        private readonly string _path;
+
+        public FileLogger()
+        {
+            var dir = Path.Combine(UnityEngine.Application.persistentDataPath, "logs");
+            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+            _path = Path.Combine(dir, $"log_{DateTime.Now:yyyyMMdd_HHmmss}.txt");
+            Info($"FantasyColony boot {UnityEngine.Application.version} Unity {UnityEngine.Application.unityVersion}");
+        }
+
+        public void Info(string msg)
+        {
+            Debug.Log(msg);
+            Append("INFO", msg);
+        }
+
+        public void Warn(string msg)
+        {
+            Debug.LogWarning(msg);
+            Append("WARN", msg);
+        }
+
+        public void Error(string msg, Exception ex = null)
+        {
+            Debug.LogError(msg);
+            if (ex != null) msg += "\n" + ex;
+            Append("ERROR", msg);
+        }
+
+        private void Append(string level, string msg)
+        {
+            try
+            {
+                File.AppendAllText(_path, $"[{DateTime.Now:HH:mm:ss}] {level} {msg}\n");
+            }
+            catch { /* ignore logging failures */ }
+        }
+    }
+}

--- a/Assets/Scripts/Core/Services/ILogger.cs.meta
+++ b/Assets/Scripts/Core/Services/ILogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57ba8d8fbe4247b1b4d5c3b93f5cfcf8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI.meta
+++ b/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e023e7aaf8594878a585f7479cff36ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Root.meta
+++ b/Assets/Scripts/UI/Root.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a9860fde2844c09832c517303fd8064
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Root/UIRoot.cs
+++ b/Assets/Scripts/UI/Root/UIRoot.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace FantasyColony.UI.Root
+{
+    public sealed class UIRoot : MonoBehaviour
+    {
+        public RectTransform ScreenParent { get; private set; }
+
+        public static UIRoot Create(Transform parent)
+        {
+            var go = new GameObject("UIRoot");
+            go.transform.SetParent(parent, false);
+            var root = go.AddComponent<UIRoot>();
+            root.Build();
+            return root;
+        }
+
+        private void Build()
+        {
+            // Canvas
+            var canvasGO = new GameObject("Canvas");
+            canvasGO.transform.SetParent(transform, false);
+            var canvas = canvasGO.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvasGO.AddComponent<GraphicRaycaster>();
+
+            var scaler = canvasGO.AddComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920, 1080);
+            scaler.matchWidthOrHeight = 0.5f;
+
+            // EventSystem if missing
+            if (FindObjectOfType<EventSystem>() == null)
+            {
+                var es = new GameObject("EventSystem");
+                es.AddComponent<EventSystem>();
+                es.AddComponent<StandaloneInputModule>();
+            }
+
+            // Screen parent
+            var screenParentGO = new GameObject("Screens");
+            screenParentGO.transform.SetParent(canvasGO.transform, false);
+            ScreenParent = screenParentGO.AddComponent<RectTransform>();
+            ScreenParent.anchorMin = Vector2.zero;
+            ScreenParent.anchorMax = Vector2.one;
+            ScreenParent.offsetMin = Vector2.zero;
+            ScreenParent.offsetMax = Vector2.zero;
+        }
+    }
+}

--- a/Assets/Scripts/UI/Root/UIRoot.cs.meta
+++ b/Assets/Scripts/UI/Root/UIRoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36072b4ec2504d129a712ae6eab41a65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Router.meta
+++ b/Assets/Scripts/UI/Router.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07c49afe82b74ef8a4a3880a6ccbcb9f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Router/IScreen.cs
+++ b/Assets/Scripts/UI/Router/IScreen.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace FantasyColony.UI.Router
+{
+    public interface IScreen
+    {
+        void Enter(Transform parent);
+        void Exit();
+    }
+
+    public abstract class UIScreenBase : IScreen
+    {
+        protected RectTransform Root;
+        public abstract void Enter(Transform parent);
+        public abstract void Exit();
+    }
+}

--- a/Assets/Scripts/UI/Router/IScreen.cs.meta
+++ b/Assets/Scripts/UI/Router/IScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33eee101958a4c0e8bfef39fc36adcf8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Router/UIRouter.cs
+++ b/Assets/Scripts/UI/Router/UIRouter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using FantasyColony.Core;
+
+namespace FantasyColony.UI.Router
+{
+    public sealed class UIRouter
+    {
+        private readonly Transform _parent;
+        private readonly ServiceRegistry _services;
+        private readonly Stack<IScreen> _stack = new();
+
+        public UIRouter(Transform parent, ServiceRegistry services)
+        {
+            _parent = parent;
+            _services = services;
+        }
+
+        public void Push<T>() where T : IScreen, new()
+        {
+            var screen = new T();
+            screen.Enter(_parent);
+            _stack.Push(screen);
+        }
+
+        public void Pop()
+        {
+            if (_stack.Count == 0) return;
+            var top = _stack.Pop();
+            top.Exit();
+        }
+    }
+}

--- a/Assets/Scripts/UI/Router/UIRouter.cs.meta
+++ b/Assets/Scripts/UI/Router/UIRouter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dd70ccaad1e42f8b6d543a28ddda033
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Screens.meta
+++ b/Assets/Scripts/UI/Screens.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1be5ddc79abd42f98fc913ddbc0b14ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using UnityEngine.UI;
+using FantasyColony.UI.Router;
+using FantasyColony.UI.Widgets;
+using FantasyColony.UI.Style;
+using FantasyColony.Core.Services;
+
+namespace FantasyColony.UI.Screens
+{
+    /// <summary>
+    /// Main Menu (non-functional for now). Uses Base UI Style, bottom-right vertical stack.
+    /// Order: Log, Start, Continue, Load, Options, Mods, Creator, Restart, Quit
+    /// </summary>
+    public sealed class MainMenuScreen : UIScreenBase
+    {
+        public override void Enter(Transform parent)
+        {
+            // Root
+            var go = new GameObject("MainMenu", typeof(RectTransform));
+            Root = go.GetComponent<RectTransform>();
+            Root.SetParent(parent, false);
+            Root.anchorMin = Vector2.zero;
+            Root.anchorMax = Vector2.one;
+            Root.offsetMin = Vector2.zero;
+            Root.offsetMax = Vector2.zero;
+
+            // Background (image if present, else solid)
+            var bgSprite = Resources.Load<Sprite>("ui/menu/main_menu_bg");
+            UIFactory.CreateFullscreenBackground(Root, bgSprite, new Color32(18, 15, 12, 255));
+
+            // Optional scrim behind panel for readability
+            var scrimGO = new GameObject("RightScrim", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            scrimGO.transform.SetParent(Root, false);
+            var srt = scrimGO.GetComponent<RectTransform>();
+            srt.anchorMin = new Vector2(0.6f, 0);
+            srt.anchorMax = new Vector2(1f, 1f);
+            srt.offsetMin = Vector2.zero;
+            srt.offsetMax = Vector2.zero;
+            var sImg = scrimGO.GetComponent<Image>();
+            sImg.color = new Color(0, 0, 0, 0.55f);
+
+            // Panel stack (bottom-right)
+            var panel = UIFactory.CreateBottomRightStack(Root, "MenuPanel");
+
+            // Buttons (log "Not implemented")
+            void NotImpl(string name) => Debug.Log($"BUTTON: {name} (not implemented)");
+
+            UIFactory.CreateButtonSecondary(panel, "Log",        () => NotImpl("Log"));
+            UIFactory.CreateButtonPrimary(panel,   "Start",      () => NotImpl("Start"));
+            var btnContinue = UIFactory.CreateButtonSecondary(panel, "Continue", () => NotImpl("Continue"));
+            var btnLoad     = UIFactory.CreateButtonSecondary(panel, "Load",     () => NotImpl("Load"));
+            UIFactory.CreateButtonSecondary(panel, "Options",    () => NotImpl("Options"));
+            UIFactory.CreateButtonSecondary(panel, "Mods",       () => NotImpl("Mods"));
+            UIFactory.CreateButtonSecondary(panel, "Creator",    () => NotImpl("Creator"));
+            UIFactory.CreateButtonSecondary(panel, "Restart",    () => NotImpl("Restart"));
+            UIFactory.CreateButtonDanger(panel,     "Quit",      () => NotImpl("Quit"));
+
+            // Disabled rules for now (no save system yet)
+            btnContinue.interactable = false;
+            btnLoad.interactable = false;
+        }
+
+        public override void Exit()
+        {
+            if (Root != null)
+            {
+                Object.Destroy(Root.gameObject);
+                Root = null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs.meta
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7ea280b501c41149af2246e1e274507
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Style.meta
+++ b/Assets/Scripts/UI/Style.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a51b1fa54aa54b16a70ef30c347bcb5a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Style/BaseUIStyle.cs
+++ b/Assets/Scripts/UI/Style/BaseUIStyle.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+namespace FantasyColony.UI.Style
+{
+    public static class BaseUIStyle
+    {
+        // Colors
+        public static Color32 Gold            = Hex("#D6B25E");
+        public static Color32 GoldHover       = Hex("#E4C77D");
+        public static Color32 GoldPressed     = Hex("#B99443");
+        public static Color32 PanelSurface    = new Color32(0x1F,0x1A,0x14, (byte)(0.95f * 255));
+        public static Color32 SecondaryFill   = Hex("#2A231B");
+        public static Color32 Keyline         = new Color32(0x5A,0x4C,0x38, (byte)(0.60f * 255));
+        public static Color32 TextPrimary     = Hex("#F1E9D2");
+        public static Color32 TextSecondary   = Hex("#C9BDA2");
+        public static Color32 Danger          = Hex("#B34844");
+        public static Color32 DangerHover     = Hex("#C8625E");
+        public static Color32 DangerPressed   = Hex("#953A37");
+
+        // Sizes
+        public const int ButtonHeight = 56;
+        public const int ButtonFontSize = 24;
+        public const int BodyFontSize = 20;
+        public const int CaptionFontSize = 18;
+        public const int PanelPadding = 24;
+        public const int StackSpacing = 12;
+        public const int EdgeOffset = 56;
+
+        public static Color32 Hex(string hex)
+        {
+            if (ColorUtility.TryParseHtmlString(hex, out var c))
+                return c;
+            return Color.white;
+        }
+    }
+}

--- a/Assets/Scripts/UI/Style/BaseUIStyle.cs.meta
+++ b/Assets/Scripts/UI/Style/BaseUIStyle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 391b34707cfd4c36a293133ed8974471
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Widgets.meta
+++ b/Assets/Scripts/UI/Widgets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7291e25ae04540b2a23c305c4f543b92
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -1,0 +1,124 @@
+using UnityEngine;
+using UnityEngine.UI;
+using FantasyColony.UI.Style;
+using System;
+
+namespace FantasyColony.UI.Widgets
+{
+    public static class UIFactory
+    {
+        // PANEL
+        public static RectTransform CreatePanelSurface(Transform parent, string name = "Panel")
+        {
+            var go = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
+            go.transform.SetParent(parent, false);
+            var rt = go.GetComponent<RectTransform>();
+            var img = go.GetComponent<Image>();
+            img.color = BaseUIStyle.PanelSurface;
+
+            var layout = go.GetComponent<VerticalLayoutGroup>();
+            layout.spacing = BaseUIStyle.StackSpacing;
+            layout.padding = new RectOffset(BaseUIStyle.PanelPadding, BaseUIStyle.PanelPadding, BaseUIStyle.PanelPadding, BaseUIStyle.PanelPadding);
+
+            var fitter = go.GetComponent<ContentSizeFitter>();
+            fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            return rt;
+        }
+
+        // BUTTONS
+        public static Button CreateButtonPrimary(Transform parent, string label, Action onClick) =>
+            CreateButton(parent, label, BaseUIStyle.Gold, BaseUIStyle.TextSecondary, onClick);
+
+        public static Button CreateButtonSecondary(Transform parent, string label, Action onClick) =>
+            CreateButton(parent, label, BaseUIStyle.SecondaryFill, BaseUIStyle.TextPrimary, onClick);
+
+        public static Button CreateButtonDanger(Transform parent, string label, Action onClick) =>
+            CreateButton(parent, label, BaseUIStyle.Danger, BaseUIStyle.TextSecondary, onClick, isDanger:true);
+
+        private static Button CreateButton(Transform parent, string label, Color fill, Color textColor, Action onClick, bool isDanger = false)
+        {
+            var go = new GameObject($"Button_{label}", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button), typeof(LayoutElement));
+            go.transform.SetParent(parent, false);
+            var rt = go.GetComponent<RectTransform>();
+            rt.sizeDelta = new Vector2(380, BaseUIStyle.ButtonHeight);
+
+            var img = go.GetComponent<Image>();
+            img.color = fill;
+
+            var btn = go.GetComponent<Button>();
+            var colors = btn.colors;
+            colors.normalColor = fill;
+            colors.highlightedColor = isDanger ? BaseUIStyle.DangerHover : (fill == BaseUIStyle.Gold ? BaseUIStyle.GoldHover : Multiply(fill, 1.06f));
+            colors.pressedColor = isDanger ? BaseUIStyle.DangerPressed : (fill == BaseUIStyle.Gold ? BaseUIStyle.GoldPressed : Multiply(fill, 0.90f));
+            colors.disabledColor = new Color(fill.r, fill.g, fill.b, 0.4f);
+            colors.colorMultiplier = 1f;
+            btn.colors = colors;
+            btn.onClick.AddListener(() => onClick?.Invoke());
+
+            // Label
+            var textGO = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
+            textGO.transform.SetParent(go.transform, false);
+            var trt = textGO.GetComponent<RectTransform>();
+            trt.anchorMin = new Vector2(0, 0);
+            trt.anchorMax = new Vector2(1, 1);
+            trt.offsetMin = new Vector2(16, 0);
+            trt.offsetMax = new Vector2(-16, 0);
+
+            var txt = textGO.GetComponent<Text>();
+            txt.text = label;
+            txt.alignment = TextAnchor.MiddleLeft;
+            txt.fontSize = BaseUIStyle.ButtonFontSize;
+            txt.color = textColor;
+            // Use default Arial to avoid TMP dependency; can swap later.
+            txt.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+
+            return btn;
+        }
+
+        // STACK CONTAINER (Bottom-right MenuPanel)
+        public static RectTransform CreateBottomRightStack(Transform parent, string name = "MenuPanel")
+        {
+            var panel = CreatePanelSurface(parent, name);
+            panel.anchorMin = new Vector2(1, 0);
+            panel.anchorMax = new Vector2(1, 0);
+            panel.pivot = new Vector2(1, 0);
+            panel.anchoredPosition = new Vector2(-BaseUIStyle.EdgeOffset, BaseUIStyle.EdgeOffset);
+
+            var layout = panel.GetComponent<VerticalLayoutGroup>();
+            layout.childAlignment = TextAnchor.UpperCenter;
+
+            var le = panel.GetComponent<LayoutElement>();
+            if (le == null) le = panel.gameObject.AddComponent<LayoutElement>();
+            le.preferredWidth = 420;
+            le.flexibleWidth = 0;
+            return panel;
+        }
+
+        // BACKGROUND IMAGE (full screen)
+        public static Image CreateFullscreenBackground(Transform parent, Sprite sprite, Color fallbackColor)
+        {
+            var go = new GameObject("Background", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            go.transform.SetParent(parent, false);
+            var rt = go.GetComponent<RectTransform>();
+            rt.anchorMin = Vector2.zero;
+            rt.anchorMax = Vector2.one;
+            rt.offsetMin = Vector2.zero;
+            rt.offsetMax = Vector2.zero;
+            var img = go.GetComponent<Image>();
+            if (sprite != null)
+            {
+                img.sprite = sprite;
+                img.preserveAspect = true;
+                img.color = Color.white;
+            }
+            else
+            {
+                img.color = fallbackColor;
+            }
+            return img;
+        }
+
+        private static Color Multiply(Color c, float f) => new Color(c.r * f, c.g * f, c.b * f, c.a);
+    }
+}

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs.meta
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6953febc4ad4bc38347b67b604601d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Introduce `AppBootstrap` and `AppHost` to initialize services and UI on startup
- Implement service registry, basic services, and UI router/root construction
- Add base UI style, UIFactory helpers, and a placeholder main menu screen

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e85640b88324b2451d6e0721ce9f