### PR TITLE
Fix ILogger ambiguity via aliases; replace deprecated FindObjectOfType with version-safe EventSystem check

### DIFF
--- a/Assets/Scripts/Core/AppHost.cs
+++ b/Assets/Scripts/Core/AppHost.cs
@@ -3,6 +3,16 @@ using FantasyColony.UI.Root;
 using FantasyColony.UI.Router;
 using FantasyColony.Core.Services;
 
+// Disambiguate our service interfaces from Unity's similarly named types
+using FCLogger = FantasyColony.Core.Services.ILogger;
+using FCFileLogger = FantasyColony.Core.Services.FileLogger;
+using FCConfigService = FantasyColony.Core.Services.IConfigService;
+using FCDummyConfig = FantasyColony.Core.Services.DummyConfigService;
+using FCEventBus = FantasyColony.Core.Services.IEventBus;
+using FCSimpleEventBus = FantasyColony.Core.Services.SimpleEventBus;
+using FCAssetProvider = FantasyColony.Core.Services.IAssetProvider;
+using FCResourcesProvider = FantasyColony.Core.Services.ResourcesAssetProvider;
+
 namespace FantasyColony.Core
 {
     /// <summary>
@@ -20,10 +30,10 @@ namespace FantasyColony.Core
             QualitySettings.vSyncCount = 0;
 
             _services = new ServiceRegistry();
-            _services.Register<ILogger>(new FileLogger());
-            _services.Register<IConfigService>(new DummyConfigService());
-            _services.Register<IEventBus>(new SimpleEventBus());
-            _services.Register<IAssetProvider>(new ResourcesAssetProvider());
+            _services.Register<FCLogger>(new FCFileLogger());
+            _services.Register<FCConfigService>(new FCDummyConfig());
+            _services.Register<FCEventBus>(new FCSimpleEventBus());
+            _services.Register<FCAssetProvider>(new FCResourcesProvider());
 
             // Create UI root (Canvas + EventSystem)
             _uiRoot = UIRoot.Create(transform);

--- a/Assets/Scripts/UI/Root/UIRoot.cs
+++ b/Assets/Scripts/UI/Root/UIRoot.cs
@@ -32,7 +32,20 @@ namespace FantasyColony.UI.Root
             scaler.matchWidthOrHeight = 0.5f;
 
             // EventSystem if missing
-            if (FindObjectOfType<EventSystem>() == null)
+            bool hasEventSystem = EventSystem.current != null;
+#if UNITY_2023_1_OR_NEWER
+            if (!hasEventSystem)
+            {
+                hasEventSystem = (Object.FindFirstObjectByType<EventSystem>() != null);
+            }
+#else
+            if (!hasEventSystem)
+            {
+                hasEventSystem = (FindObjectOfType<EventSystem>() != null);
+            }
+#endif
+
+            if (!hasEventSystem)
             {
                 var es = new GameObject("EventSystem");
                 es.AddComponent<EventSystem>();


### PR DESCRIPTION
## Summary
- disambiguate custom service interfaces from Unity types with aliases
- replace deprecated `FindObjectOfType` with Unity-version-safe EventSystem lookup

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3eb75e9f08324977f56554e0c41dd