### PR TITLE
Fix main menu layout and panel transparency

### DIFF
--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -28,19 +28,12 @@ namespace FantasyColony.UI.Screens
             var bgSprite = Resources.Load<Sprite>("ui/menu/main_menu_bg");
             UIFactory.CreateFullscreenBackground(Root, bgSprite, new Color32(18, 15, 12, 255));
 
-            // Optional scrim behind panel for readability
-            var scrimGO = new GameObject("RightScrim", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
-            scrimGO.transform.SetParent(Root, false);
-            var srt = scrimGO.GetComponent<RectTransform>();
-            srt.anchorMin = new Vector2(0.6f, 0);
-            srt.anchorMax = new Vector2(1f, 1f);
-            srt.offsetMin = Vector2.zero;
-            srt.offsetMax = Vector2.zero;
-            var sImg = scrimGO.GetComponent<Image>();
-            sImg.color = new Color(0, 0, 0, 0.55f);
-
             // Panel stack (bottom-right)
             var panel = UIFactory.CreateBottomRightStack(Root, "MenuPanel");
+            // Make panel background transparent (no shadow panel), keep layout behavior
+            var panelImg = panel.GetComponent<Image>();
+            if (panelImg) panelImg.color = new Color(0,0,0,0);
+            panel.SetAsLastSibling();
 
             // Buttons (log "Not implemented")
             void NotImpl(string name) => Debug.Log($"BUTTON: {name} (not implemented)");

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -19,6 +19,11 @@ namespace FantasyColony.UI.Widgets
             var layout = go.GetComponent<VerticalLayoutGroup>();
             layout.spacing = BaseUIStyle.StackSpacing;
             layout.padding = new RectOffset(BaseUIStyle.PanelPadding, BaseUIStyle.PanelPadding, BaseUIStyle.PanelPadding, BaseUIStyle.PanelPadding);
+            // Ensure children (buttons) get proper space and panel wraps to content reliably
+            layout.childControlWidth = true;
+            layout.childControlHeight = true;
+            layout.childForceExpandWidth = false;
+            layout.childForceExpandHeight = false;
 
             var fitter = go.GetComponent<ContentSizeFitter>();
             fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
@@ -55,6 +60,12 @@ namespace FantasyColony.UI.Widgets
             colors.colorMultiplier = 1f;
             btn.colors = colors;
             btn.onClick.AddListener(() => onClick?.Invoke());
+
+            // Layout sizing so buttons are visible in the stack
+            var le = go.GetComponent<LayoutElement>();
+            le.preferredWidth = 420;
+            le.minHeight = BaseUIStyle.ButtonHeight;
+            le.flexibleWidth = 0; le.flexibleHeight = 0;
 
             // Label
             var textGO = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
@@ -109,7 +120,7 @@ namespace FantasyColony.UI.Widgets
             if (sprite != null)
             {
                 img.sprite = sprite;
-                img.preserveAspect = true;
+                img.preserveAspect = true; // Placeholder background scaling; fills via CanvasScaler
                 img.color = Color.white;
             }
             else


### PR DESCRIPTION
## Summary
- remove opaque scrim and display main menu without shadow panel
- ensure panel and buttons size themselves correctly for consistent layout
- document background scaling behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f0e977cc8324ae86d81d26efe0f9