### PR TITLE
Main Menu: improve button feedback and prevent raycast blocking

### DIFF
--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -32,7 +32,11 @@ namespace FantasyColony.UI.Screens
             var panel = UIFactory.CreateBottomRightStack(Root, "MenuPanel");
             // Make panel background transparent (no shadow panel), keep layout behavior
             var panelImg = panel.GetComponent<Image>();
-            if (panelImg) panelImg.color = new Color(0,0,0,0);
+            if (panelImg)
+            {
+                panelImg.color = new Color(0,0,0,0);
+                panelImg.raycastTarget = false; // do not block button mouse events
+            }
             panel.SetAsLastSibling();
 
             // Buttons (log "Not implemented")

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -52,13 +52,18 @@ namespace FantasyColony.UI.Widgets
             img.color = fill;
 
             var btn = go.GetComponent<Button>();
+            btn.targetGraphic = img; // ensure transitions target our Image
+            btn.transition = Selectable.Transition.ColorTint;
             var colors = btn.colors;
             colors.normalColor = fill;
-            colors.highlightedColor = isDanger ? BaseUIStyle.DangerHover : (fill == BaseUIStyle.Gold ? BaseUIStyle.GoldHover : Multiply(fill, 1.06f));
-            colors.pressedColor = isDanger ? BaseUIStyle.DangerPressed : (fill == BaseUIStyle.Gold ? BaseUIStyle.GoldPressed : Multiply(fill, 0.90f));
-            colors.disabledColor = new Color(fill.r, fill.g, fill.b, 0.4f);
+            // Stronger deltas for clearer feedback
+            colors.highlightedColor = isDanger ? BaseUIStyle.DangerHover : (fill == BaseUIStyle.Gold ? BaseUIStyle.GoldHover : Multiply(fill, 1.15f));
+            colors.pressedColor    = isDanger ? BaseUIStyle.DangerPressed : (fill == BaseUIStyle.Gold ? BaseUIStyle.GoldPressed : Multiply(fill, 0.80f));
+            colors.selectedColor   = colors.highlightedColor;
+            colors.disabledColor   = new Color(fill.r, fill.g, fill.b, 0.35f);
             colors.colorMultiplier = 1f;
             btn.colors = colors;
+            btn.fadeDuration = 0.08f;
             btn.onClick.AddListener(() => onClick?.Invoke());
 
             // Layout sizing so buttons are visible in the stack
@@ -120,13 +125,14 @@ namespace FantasyColony.UI.Widgets
             if (sprite != null)
             {
                 img.sprite = sprite;
-                img.preserveAspect = true; // Placeholder background scaling; fills via CanvasScaler
+                img.preserveAspect = true; // Background should not intercept clicks
                 img.color = Color.white;
             }
             else
             {
                 img.color = fallbackColor;
             }
+            img.raycastTarget = false; // never block UI
             return img;
         }
 


### PR DESCRIPTION
## Summary
- Highlight main menu buttons with stronger hover/press colors and faster transitions
- Prevent fullscreen background and panel images from intercepting raycasts

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f2edee988324ab41df882f8d15cf