### PR TITLE
Fix: set fadeDuration on ColorBlock instead of Button (CS1061)

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -62,8 +62,8 @@ namespace FantasyColony.UI.Widgets
             colors.selectedColor   = colors.highlightedColor;
             colors.disabledColor   = new Color(fill.r, fill.g, fill.b, 0.35f);
             colors.colorMultiplier = 1f;
+            colors.fadeDuration    = 0.08f;
             btn.colors = colors;
-            btn.fadeDuration = 0.08f;
             btn.onClick.AddListener(() => onClick?.Invoke());
 
             // Layout sizing so buttons are visible in the stack


### PR DESCRIPTION
## Summary
- fix fadeDuration assignment by setting it on ColorBlock before applying to Button

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f62dc78083248a1acdd61a1865ad