### PR TITLE
Add explicit Secondary UI hover/press colors

### DIFF
--- a/Assets/Scripts/UI/Style/BaseUIStyle.cs
+++ b/Assets/Scripts/UI/Style/BaseUIStyle.cs
@@ -10,6 +10,8 @@ namespace FantasyColony.UI.Style
         public static Color32 GoldPressed     = Hex("#B99443");
         public static Color32 PanelSurface    = new Color32(0x1F,0x1A,0x14, (byte)(0.95f * 255));
         public static Color32 SecondaryFill   = Hex("#2A231B");
+        public static Color32 SecondaryHover  = Hex("#383026");
+        public static Color32 SecondaryPressed= Hex("#241F17");
         public static Color32 Keyline         = new Color32(0x5A,0x4C,0x38, (byte)(0.60f * 255));
         public static Color32 TextPrimary     = Hex("#F1E9D2");
         public static Color32 TextSecondary   = Hex("#C9BDA2");

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -56,9 +56,21 @@ namespace FantasyColony.UI.Widgets
             btn.transition = Selectable.Transition.ColorTint;
             var colors = btn.colors;
             colors.normalColor = fill;
-            // Stronger deltas for clearer feedback
-            colors.highlightedColor = isDanger ? BaseUIStyle.DangerHover : (fill == BaseUIStyle.Gold ? BaseUIStyle.GoldHover : Multiply(fill, 1.15f));
-            colors.pressedColor    = isDanger ? BaseUIStyle.DangerPressed : (fill == BaseUIStyle.Gold ? BaseUIStyle.GoldPressed : Multiply(fill, 0.80f));
+            // Stronger deltas for clearer feedback. SecondaryFill uses explicit palette values
+            colors.highlightedColor = isDanger
+                ? BaseUIStyle.DangerHover
+                : (fill == BaseUIStyle.Gold
+                    ? BaseUIStyle.GoldHover
+                    : (fill == BaseUIStyle.SecondaryFill
+                        ? BaseUIStyle.SecondaryHover
+                        : Multiply(fill, 1.15f)));
+            colors.pressedColor = isDanger
+                ? BaseUIStyle.DangerPressed
+                : (fill == BaseUIStyle.Gold
+                    ? BaseUIStyle.GoldPressed
+                    : (fill == BaseUIStyle.SecondaryFill
+                        ? BaseUIStyle.SecondaryPressed
+                        : Multiply(fill, 0.80f)));
             colors.selectedColor   = colors.highlightedColor;
             colors.disabledColor   = new Color(fill.r, fill.g, fill.b, 0.35f);
             colors.colorMultiplier = 1f;


### PR DESCRIPTION
## Summary
- Add secondary hover and pressed colors to base UI style for better contrast
- Update button factory to use secondary palette values when deriving state colors

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fd9ce9288324a838c26187585d56