### PR TITLE
Brighten secondary UI button palette

### DIFF
--- a/Assets/Scripts/UI/Style/BaseUIStyle.cs
+++ b/Assets/Scripts/UI/Style/BaseUIStyle.cs
@@ -9,10 +9,14 @@ namespace FantasyColony.UI.Style
         public static Color32 GoldHover       = Hex("#E4C77D");
         public static Color32 GoldPressed     = Hex("#B99443");
         public static Color32 PanelSurface    = new Color32(0x1F,0x1A,0x14, (byte)(0.95f * 255));
-        // Secondary palette tuned for clearer hover/click contrast
-        public static Color32 SecondaryFill   = Hex("#3B3329"); // Lightened from #2A231B
-        public static Color32 SecondaryHover  = Hex("#4A4033"); // Noticeably lighter than base
-        public static Color32 SecondaryPressed= Hex("#2A231B"); // Old base as pressed state
+        // Secondary (dark) fill used for standard buttons - BRIGHTENED for better visibility on dark backgrounds
+        // Old values kept in comments for reference
+        // Previous: #3B3329 (0.231, 0.200, 0.161)
+        public static Color32 SecondaryFill   = Hex("#5E5345"); // #5E5345
+        // Secondary (dark) explicit states for visible hover/press
+        // Hover: noticeably lighter than base; Pressed: slightly darker than new base
+        public static Color32 SecondaryHover  = Hex("#726555"); // #726555
+        public static Color32 SecondaryPressed= Hex("#4A4033"); // Slightly darker than new base
         public static Color32 Keyline         = new Color32(0x5A,0x4C,0x38, (byte)(0.60f * 255));
         public static Color32 TextPrimary     = Hex("#F1E9D2");
         public static Color32 TextSecondary   = Hex("#C9BDA2");


### PR DESCRIPTION
## Summary
- brighten secondary button palette for better visibility on dark backgrounds

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4034a737c8324829d296e2b2d63db