### PR TITLE
Main Menu: wire Quit button to actually exit

### DIFF
--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -50,7 +50,7 @@ namespace FantasyColony.UI.Screens
             UIFactory.CreateButtonSecondary(panel, "Mods",       () => NotImpl("Mods"));
             UIFactory.CreateButtonSecondary(panel, "Creator",    () => NotImpl("Creator"));
             UIFactory.CreateButtonSecondary(panel, "Restart",    () => NotImpl("Restart"));
-            UIFactory.CreateButtonDanger(panel,     "Quit",      () => NotImpl("Quit"));
+            UIFactory.CreateButtonDanger(panel,     "Quit",      QuitGame);
 
             // Disabled rules for now (no save system yet)
             btnContinue.interactable = false;
@@ -64,6 +64,15 @@ namespace FantasyColony.UI.Screens
                 Object.Destroy(Root.gameObject);
                 Root = null;
             }
+        }
+
+        private static void QuitGame()
+        {
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.ExitPlaymode();
+#else
+            Application.Quit();
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wire Main Menu Quit button to invoke actual game exit logic
- QuitGame handles editor ExitPlaymode and built Application.Quit

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b40869d798832490b2b3a7a82519ad