### PR TITLE
Restart behavior: avoid scene reload

### DIFF
--- a/Assets/Scripts/UI/Router/UIRouter.cs
+++ b/Assets/Scripts/UI/Router/UIRouter.cs
@@ -11,10 +11,14 @@ namespace FantasyColony.UI.Router
         private readonly ServiceRegistry _services;
         private readonly Stack<IScreen> _stack = new();
 
+        // Global access to the active router (useful for simple buttons like Restart)
+        public static UIRouter Current { get; private set; }
+
         public UIRouter(Transform parent, ServiceRegistry services)
         {
             _parent = parent;
             _services = services;
+            Current = this;
         }
 
         public void Push<T>() where T : IScreen, new()
@@ -29,6 +33,18 @@ namespace FantasyColony.UI.Router
             if (_stack.Count == 0) return;
             var top = _stack.Pop();
             top.Exit();
+        }
+
+        // --- Restart helpers ---
+        public void PopAll()
+        {
+            while (_stack.Count > 0) Pop();
+        }
+
+        public void ResetTo<T>() where T : IScreen, new()
+        {
+            PopAll();
+            Push<T>();
         }
     }
 }

--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-using UnityEngine.SceneManagement;
+using System;
 using FantasyColony.UI.Router;
 using FantasyColony.UI.Widgets;
 using FantasyColony.UI.Style;
@@ -67,20 +67,23 @@ namespace FantasyColony.UI.Screens
             }
         }
 
-        private static void RestartGame()
+        private void RestartGame()
         {
-            // Ensure normal time scale and reload the initial boot scene to mimic a fresh launch
+            // Normalize timescale and reset the UI stack to simulate a fresh boot
             Time.timeScale = 1f;
-            SceneManager.LoadScene(0);
+            UIRouter.Current?.ResetTo<MainMenuScreen>();
+            // Optional hygiene to mirror a clean boot over time as content grows
+            Resources.UnloadUnusedAssets();
+            System.GC.Collect();
         }
 
-        private static void QuitGame()
+        private void QuitGame()
         {
-#if UNITY_EDITOR
+        #if UNITY_EDITOR
             UnityEditor.EditorApplication.ExitPlaymode();
-#else
+        #else
             Application.Quit();
-#endif
+        #endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose a global UIRouter.Current instance and add PopAll/ResetTo helpers
- restart via resetting the router stack instead of scene reload
- clean up unused assets and GC when restarting from main menu

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b40d33875c83248896e98b96d6fffd