### PR TITLE
Fix CS0104 ambiguity by qualifying UnityEngine.Object in MainMenuScreen

### DIFF
--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -5,6 +5,7 @@ using FantasyColony.UI.Router;
 using FantasyColony.UI.Widgets;
 using FantasyColony.UI.Style;
 using FantasyColony.Core.Services;
+using UnityObject = UnityEngine.Object;
 
 namespace FantasyColony.UI.Screens
 {
@@ -62,7 +63,7 @@ namespace FantasyColony.UI.Screens
         {
             if (Root != null)
             {
-                Object.Destroy(Root.gameObject);
+                UnityObject.Destroy(Root.gameObject);
                 Root = null;
             }
         }


### PR DESCRIPTION
## Summary
- qualify UnityEngine.Object to resolve CS0104 ambiguity

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b40eb9b46483249f44f6bb4f72f834