### PR TITLE
Fix ConfirmDialog: pass Transform to UIFactory button creators; add Widgets using

### DIFF
--- a/Assets/Scripts/UI/Screens/ConfirmDialogScreen.cs
+++ b/Assets/Scripts/UI/Screens/ConfirmDialogScreen.cs
@@ -87,13 +87,13 @@ namespace FantasyColony.UI.Screens
             rowLayout.padding = new RectOffset(0, 0, 8, 0);
 
             // Cancel / Confirm buttons using UIFactory
-            UIFactory.CreateButtonSecondary(row, string.IsNullOrEmpty(CancelLabel) ? "Cancel" : CancelLabel, () =>
+            UIFactory.CreateButtonSecondary(row.transform, string.IsNullOrEmpty(CancelLabel) ? "Cancel" : CancelLabel, () =>
             {
                 UIRouter.Current?.Pop();
                 OnCancel?.Invoke();
             });
 
-            UIFactory.CreateButtonDanger(row, string.IsNullOrEmpty(ConfirmLabel) ? "OK" : ConfirmLabel, () =>
+            UIFactory.CreateButtonDanger(row.transform, string.IsNullOrEmpty(ConfirmLabel) ? "OK" : ConfirmLabel, () =>
             {
                 var router = UIRouter.Current;
                 router?.Pop(); // close dialog first so new screens appear above


### PR DESCRIPTION
## Summary
- Pass Transform when creating ConfirmDialog buttons so they attach to the row
- Ensure Widgets namespace is imported for button creation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed / 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b414ad63a48324a73a9919deab1042