### PR TITLE
UI textured wood panels and button overlays

### DIFF
--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -34,13 +34,6 @@ namespace FantasyColony.UI.Screens
 
             // Panel stack (bottom-right)
             var panel = UIFactory.CreateBottomRightStack(Root, "MenuPanel");
-            // Make panel background transparent (no shadow panel), keep layout behavior
-            var panelImg = panel.GetComponent<Image>();
-            if (panelImg)
-            {
-                panelImg.color = new Color(0,0,0,0);
-                panelImg.raycastTarget = false; // do not block button mouse events
-            }
             panel.SetAsLastSibling();
 
             // Buttons (log "Not implemented")

--- a/Assets/Scripts/UI/Style/BaseUIStyle.cs
+++ b/Assets/Scripts/UI/Style/BaseUIStyle.cs
@@ -24,6 +24,17 @@ namespace FantasyColony.UI.Style
         public static Color32 DangerHover     = Hex("#C8625E");
         public static Color32 DangerPressed   = Hex("#953A37");
 
+        // --- Textured UI assets ---
+        // Resource paths (under Assets/Resources)
+        public const string WoodTilePath = "ui/sprites/tile/wood_soft_tile";
+        public const string DarkBorder9SPath = "ui/sprites/9slice/border_dark_9s";
+
+        // Overlay tints for Button.state (applied to a transparent overlay Image)
+        // Keep subtle so textures are not washed out
+        public static readonly Color HoverOverlay   = new Color(1f, 1f, 1f, 0.06f);
+        public static readonly Color PressedOverlay = new Color(0f, 0f, 0f, 0.10f);
+        public static readonly Color DisabledOverlay= new Color(0f, 0f, 0f, 0.40f);
+
         // Sizes
         public const int ButtonHeight = 56;
         public const int ButtonFontSize = 24;

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -8,81 +8,104 @@ namespace FantasyColony.UI.Widgets
 {
     public static class UIFactory
     {
-        // PANEL
+        // PANEL (Textured wood fill + dark 9-slice border)
         public static RectTransform CreatePanelSurface(Transform parent, string name = "Panel")
         {
             var go = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
             go.transform.SetParent(parent, false);
+
             var rt = go.GetComponent<RectTransform>();
             var img = go.GetComponent<Image>();
-            img.color = BaseUIStyle.PanelSurface;
 
+            // Layout configuration (unchanged)
             var layout = go.GetComponent<VerticalLayoutGroup>();
             layout.spacing = BaseUIStyle.StackSpacing;
             layout.padding = new RectOffset(BaseUIStyle.PanelPadding, BaseUIStyle.PanelPadding, BaseUIStyle.PanelPadding, BaseUIStyle.PanelPadding);
-            // Ensure children (buttons) get proper space and panel wraps to content reliably
             layout.childControlWidth = true;
             layout.childControlHeight = true;
             layout.childForceExpandWidth = false;
             layout.childForceExpandHeight = false;
-
             var fitter = go.GetComponent<ContentSizeFitter>();
             fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
             fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            // --- Fill (tiled wood) ---
+            var fillGO = new GameObject("BG_Fill", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(LayoutElement));
+            fillGO.transform.SetParent(go.transform, false);
+            var fillRt = fillGO.GetComponent<RectTransform>();
+            fillRt.anchorMin = Vector2.zero; fillRt.anchorMax = Vector2.one;
+            fillRt.offsetMin = Vector2.zero; fillRt.offsetMax = Vector2.zero;
+            var fillImg = fillGO.GetComponent<Image>();
+            fillImg.raycastTarget = false;
+            var le = fillGO.GetComponent<LayoutElement>();
+            le.ignoreLayout = true;
+            var wood = Resources.Load<Sprite>(BaseUIStyle.WoodTilePath);
+            if (wood != null) { fillImg.sprite = wood; fillImg.type = Image.Type.Tiled; }
+            else { fillImg.color = BaseUIStyle.SecondaryFill; }
+
+            // --- Border (9-slice) on root Image ---
+            var border = Resources.Load<Sprite>(BaseUIStyle.DarkBorder9SPath);
+            if (border != null) { img.sprite = border; img.type = Image.Type.Sliced; img.color = Color.white; }
+            else { img.color = BaseUIStyle.PanelSurface; }
+
             return rt;
         }
 
         // BUTTONS
-        public static Button CreateButtonPrimary(Transform parent, string label, Action onClick) =>
-            CreateButton(parent, label, BaseUIStyle.Gold, BaseUIStyle.TextSecondary, onClick);
+        public static Button CreateButtonPrimary(Transform parent, string label, Action onClick) => CreateButton(parent, label, BaseUIStyle.Gold, BaseUIStyle.TextSecondary, onClick);
+        public static Button CreateButtonSecondary(Transform parent, string label, Action onClick) => CreateButton(parent, label, BaseUIStyle.SecondaryFill, BaseUIStyle.TextPrimary, onClick);
+        public static Button CreateButtonDanger(Transform parent, string label, Action onClick) => CreateButton(parent, label, BaseUIStyle.Danger, BaseUIStyle.TextSecondary, onClick, isDanger:true);
 
-        public static Button CreateButtonSecondary(Transform parent, string label, Action onClick) =>
-            CreateButton(parent, label, BaseUIStyle.SecondaryFill, BaseUIStyle.TextPrimary, onClick);
-
-        public static Button CreateButtonDanger(Transform parent, string label, Action onClick) =>
-            CreateButton(parent, label, BaseUIStyle.Danger, BaseUIStyle.TextSecondary, onClick, isDanger:true);
-
+        // Textured button: tiled wood fill + 9-slice dark border + overlay for state tints
         private static Button CreateButton(Transform parent, string label, Color fill, Color textColor, Action onClick, bool isDanger = false)
         {
             var go = new GameObject($"Button_{label}", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button), typeof(LayoutElement));
             go.transform.SetParent(parent, false);
+
             var rt = go.GetComponent<RectTransform>();
             rt.sizeDelta = new Vector2(380, BaseUIStyle.ButtonHeight);
 
             var img = go.GetComponent<Image>();
-            img.color = fill;
-
             var btn = go.GetComponent<Button>();
+
+            // --- Background fill (wood, tiled) ---
+            var fillGO = new GameObject("BG_Fill", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(LayoutElement));
+            fillGO.transform.SetParent(go.transform, false);
+            var fillRt = fillGO.GetComponent<RectTransform>();
+            fillRt.anchorMin = Vector2.zero; fillRt.anchorMax = Vector2.one;
+            fillRt.offsetMin = Vector2.zero; fillRt.offsetMax = Vector2.zero;
+            var fillImg = fillGO.GetComponent<Image>();
+            fillImg.raycastTarget = false;
+            fillGO.GetComponent<LayoutElement>().ignoreLayout = true;
+            var wood = Resources.Load<Sprite>(BaseUIStyle.WoodTilePath);
+            if (wood != null) { fillImg.sprite = wood; fillImg.type = Image.Type.Tiled; }
+            else { fillImg.color = fill; }
+
+            // --- Border (9-slice) on root image ---
+            var border = Resources.Load<Sprite>(BaseUIStyle.DarkBorder9SPath);
+            if (border != null) { img.sprite = border; img.type = Image.Type.Sliced; img.color = Color.white; }
+            else { img.color = fill; }
+
+            // --- Overlay for state tints (Button.targetGraphic) ---
+            var overlayGO = new GameObject("Overlay", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(LayoutElement));
+            overlayGO.transform.SetParent(go.transform, false);
+            var overlayRt = overlayGO.GetComponent<RectTransform>();
+            overlayRt.anchorMin = Vector2.zero; overlayRt.anchorMax = Vector2.one;
+            overlayRt.offsetMin = Vector2.zero; overlayRt.offsetMax = Vector2.zero;
+            var overlayImg = overlayGO.GetComponent<Image>();
+            overlayImg.color = new Color(1,1,1,0f);
+            overlayImg.raycastTarget = false;
+            overlayGO.GetComponent<LayoutElement>().ignoreLayout = true;
+
+            // Button setup
             btn.transition = Selectable.Transition.ColorTint;
-            btn.targetGraphic = img;
+            btn.targetGraphic = overlayImg; // only overlay is tinted by ColorBlock
             var colors = btn.colors;
-            colors.normalColor = fill;
-
-            // Use explicit palette values to guarantee visible state changes for known fills
-            if (isDanger)
-            {
-                colors.highlightedColor = BaseUIStyle.DangerHover;
-                colors.pressedColor = BaseUIStyle.DangerPressed;
-            }
-            else if (fill == BaseUIStyle.Gold)
-            {
-                colors.highlightedColor = BaseUIStyle.GoldHover;
-                colors.pressedColor = BaseUIStyle.GoldPressed;
-            }
-            else if (fill == BaseUIStyle.SecondaryFill)
-            {
-                colors.highlightedColor = BaseUIStyle.SecondaryHover;
-                colors.pressedColor = BaseUIStyle.SecondaryPressed;
-            }
-            else
-            {
-                colors.highlightedColor = Multiply(fill, 1.15f);
-                colors.pressedColor = Multiply(fill, 0.80f);
-            }
-
-            // Ensure selected state does not appear "stuck pressed" after click
+            colors.normalColor = new Color(1,1,1,0f); // transparent overlay
+            colors.highlightedColor = BaseUIStyle.HoverOverlay;
+            colors.pressedColor = BaseUIStyle.PressedOverlay;
             colors.selectedColor = colors.normalColor;
-            colors.disabledColor = new Color(fill.r, fill.g, fill.b, 0.35f);
+            colors.disabledColor = BaseUIStyle.DisabledOverlay;
             colors.colorMultiplier = 1f;
             colors.fadeDuration = 0.08f;
             btn.colors = colors;
@@ -92,7 +115,8 @@ namespace FantasyColony.UI.Widgets
             var le = go.GetComponent<LayoutElement>();
             le.preferredWidth = 420;
             le.minHeight = BaseUIStyle.ButtonHeight;
-            le.flexibleWidth = 0; le.flexibleHeight = 0;
+            le.flexibleWidth = 0;
+            le.flexibleHeight = 0;
 
             // Label
             var textGO = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
@@ -102,15 +126,11 @@ namespace FantasyColony.UI.Widgets
             trt.anchorMax = new Vector2(1, 1);
             trt.offsetMin = new Vector2(16, 0);
             trt.offsetMax = new Vector2(-16, 0);
-
             var txt = textGO.GetComponent<Text>();
             txt.text = label;
             txt.alignment = TextAnchor.MiddleLeft;
             txt.fontSize = BaseUIStyle.ButtonFontSize;
             txt.color = textColor;
-            // Use default Arial to avoid TMP dependency; can swap later.
-            txt.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
-
             return btn;
         }
 


### PR DESCRIPTION
## Summary
- add resource paths and overlay tints for textured UI assets
- render wood tile + dark 9-slice borders for panels and buttons
- remove transparent panel override on main menu to show new chrome

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b42b41405083249463c9ab5e5504f0