### PR TITLE
UI: toggle panel chrome and refine widget draw order

### DIFF
--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -34,7 +34,8 @@ namespace FantasyColony.UI.Screens
 
             // Panel stack (bottom-right)
             var panel = UIFactory.CreateBottomRightStack(Root, "MenuPanel");
-            panel.SetAsLastSibling();
+            // Hide panel chrome so buttons sit directly on the background art (previous behavior)
+            UIFactory.SetPanelDecorVisible(panel, false);
 
             // Buttons (log "Not implemented")
             void NotImpl(string name) => Debug.Log($"BUTTON: {name} (not implemented)");


### PR DESCRIPTION
## Summary
- ensure panel and button borders render above tiled fills while keeping root images non-visual
- add `SetPanelDecorVisible` helper and hide MainMenu stack's chrome

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b42e6f1bd08324b8f05b11f0e821c2