### PR TITLE
Normalize Core namespaces

### DIFF
--- a/Assets/Scripts/Boot/AppBootstrap.cs
+++ b/Assets/Scripts/Boot/AppBootstrap.cs
@@ -22,7 +22,7 @@ namespace FantasyColony.Boot
             setPhase?.Invoke("Loading configuration...");
             try
             {
-                Core.Services.JsonConfigService.Instance.Load();
+                FantasyColony.Core.Services.JsonConfigService.Instance.Load();
             }
             catch (Exception e)
             {
@@ -32,16 +32,16 @@ namespace FantasyColony.Boot
 
             // Phase 2: Discover Mods
             setPhase?.Invoke("Discovering mods...");
-            List<Core.Mods.ModInfo> mods = null;
+            List<FantasyColony.Core.Mods.ModInfo> mods = null;
             try
             {
-                mods = Core.Mods.ModDiscovery.Discover();
+                mods = FantasyColony.Core.Mods.ModDiscovery.Discover();
                 Debug.Log($"Mods discovered: {mods.Count}");
             }
             catch (Exception e)
             {
                 Debug.LogWarning($"Mod discovery failed: {e.Message}");
-                mods = new List<Core.Mods.ModInfo>();
+                mods = new List<FantasyColony.Core.Mods.ModInfo>();
             }
             yield return null;
 
@@ -49,9 +49,9 @@ namespace FantasyColony.Boot
             setPhase?.Invoke("Loading defs...");
             try
             {
-                var reg = Core.Services.DefRegistry.Instance;
-                var errors = new List<Core.Mods.DefError>();
-                Core.Mods.XmlDefLoader.Load(mods, reg, errors);
+                var reg = FantasyColony.Core.Services.DefRegistry.Instance;
+                var errors = new List<FantasyColony.Core.Mods.DefError>();
+                FantasyColony.Core.Mods.XmlDefLoader.Load(mods, reg, errors);
                 if (errors.Count > 0)
                 {
                     Debug.LogWarning($"Defs loaded with {errors.Count} issues. See log for details.");
@@ -71,22 +71,22 @@ namespace FantasyColony.Boot
             setPhase?.Invoke("Initializing services...");
             try
             {
-                var cfg = Core.Services.JsonConfigService.Instance;
+                var cfg = FantasyColony.Core.Services.JsonConfigService.Instance;
 
                 // Localization
                 var lang = cfg.Get("language", "en");
-                Core.Services.LocService.Instance.SetLanguage(lang);
+                FantasyColony.Core.Services.LocService.Instance.SetLanguage(lang);
 
                 // Audio (volumes default 1.0)
                 float vMaster = Parse01(cfg.Get("vol_master", "1"));
                 float vMusic = Parse01(cfg.Get("vol_music", "1"));
                 float vSfx = Parse01(cfg.Get("vol_sfx", "1"));
-                Core.Services.AudioService.Instance.SetVolume("master", vMaster);
-                Core.Services.AudioService.Instance.SetVolume("music", vMusic);
-                Core.Services.AudioService.Instance.SetVolume("sfx", vSfx);
+                FantasyColony.Core.Services.AudioService.Instance.SetVolume("master", vMaster);
+                FantasyColony.Core.Services.AudioService.Instance.SetVolume("music", vMusic);
+                FantasyColony.Core.Services.AudioService.Instance.SetVolume("sfx", vSfx);
 
                 // Save service touch (build slot cache)
-                Core.Services.JsonSaveService.Instance.RefreshCache();
+                FantasyColony.Core.Services.JsonSaveService.Instance.RefreshCache();
             }
             catch (Exception e)
             {

--- a/Assets/Scripts/Core/BuildInfo.cs
+++ b/Assets/Scripts/Core/BuildInfo.cs
@@ -1,4 +1,4 @@
-namespace Core
+namespace FantasyColony.Core
 {
     /// <summary>
     /// Static build info for diagnostics; can be auto-generated later by an Editor script.
@@ -11,10 +11,10 @@ namespace Core
     }
 }
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     public static class BuildInfoRuntime
     {
-        public static string Describe() => $"v{Core.BuildInfo.Version} ({Core.BuildInfo.Commit}) | Unity {UnityEngine.Application.unityVersion}";
+        public static string Describe() => $"v{FantasyColony.Core.BuildInfo.Version} ({FantasyColony.Core.BuildInfo.Commit}) | Unity {UnityEngine.Application.unityVersion}";
     }
 }

--- a/Assets/Scripts/Core/Input/InputRouter.cs
+++ b/Assets/Scripts/Core/Input/InputRouter.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace Core.Input
+namespace FantasyColony.Core.Input
 {
     /// <summary>
     /// Placeholder router for the new Input System. No-ops if the package is missing.

--- a/Assets/Scripts/Core/Mods/ModDiscovery.cs
+++ b/Assets/Scripts/Core/Mods/ModDiscovery.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-namespace Core.Mods
+namespace FantasyColony.Core.Mods
 {
     public class ModInfo
     {

--- a/Assets/Scripts/Core/Mods/XmlDefLoader.cs
+++ b/Assets/Scripts/Core/Mods/XmlDefLoader.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Xml.Linq;
 using UnityEngine;
 
-namespace Core.Mods
+namespace FantasyColony.Core.Mods
 {
     public class DefError
     {
@@ -18,7 +18,7 @@ namespace Core.Mods
     /// </summary>
     public static class XmlDefLoader
     {
-        public static void Load(List<ModInfo> mods, Core.Services.DefRegistry registry, List<DefError> errors)
+        public static void Load(List<ModInfo> mods, FantasyColony.Core.Services.DefRegistry registry, List<DefError> errors)
         {
             if (mods == null || registry == null) return;
             foreach (var mod in mods)

--- a/Assets/Scripts/Core/Services/AudioService.cs
+++ b/Assets/Scripts/Core/Services/AudioService.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     /// <summary>
     /// Lightweight audio bootstrap: one BGM source and one-shot SFX source.

--- a/Assets/Scripts/Core/Services/DefRegistry.cs
+++ b/Assets/Scripts/Core/Services/DefRegistry.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     /// <summary>
     /// Extremely simple definition registry keyed by type then id.

--- a/Assets/Scripts/Core/Services/JsonConfigService.cs
+++ b/Assets/Scripts/Core/Services/JsonConfigService.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     /// <summary>
     /// Minimal JSON-backed config service with string Get/Set to avoid API churn.

--- a/Assets/Scripts/Core/Services/JsonSaveService.cs
+++ b/Assets/Scripts/Core/Services/JsonSaveService.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     public struct SaveSlotMeta
     {

--- a/Assets/Scripts/Core/Services/LocService.cs
+++ b/Assets/Scripts/Core/Services/LocService.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     /// <summary>
     /// Minimal localization service. Loads Resources/Localization/{lang}/strings.json (TextAsset).


### PR DESCRIPTION
## Summary
- align Core namespaces under `FantasyColony.Core`
- fix BuildInfoRuntime reference
- update bootstrap to call new namespaces

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b440d11e348324a96ff6e0622647ee