### PR TITLE
Normalize Core namespaces

### DIFF
--- a/Assets/Scripts/Core/BuildInfo.cs
+++ b/Assets/Scripts/Core/BuildInfo.cs
@@ -1,4 +1,4 @@
-namespace Core
+namespace FantasyColony.Core
 {
     /// <summary>
     /// Static build info for diagnostics; can be auto-generated later by an Editor script.
@@ -11,10 +11,10 @@ namespace Core
     }
 }
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     public static class BuildInfoRuntime
     {
-        public static string Describe() => $"v{Core.BuildInfo.Version} ({Core.BuildInfo.Commit}) | Unity {UnityEngine.Application.unityVersion}";
+        public static string Describe() => $"v{FantasyColony.Core.BuildInfo.Version} ({FantasyColony.Core.BuildInfo.Commit}) | Unity {UnityEngine.Application.unityVersion}";
     }
 }

--- a/Assets/Scripts/Core/Input/InputRouter.cs
+++ b/Assets/Scripts/Core/Input/InputRouter.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace Core.Input
+namespace FantasyColony.Core.Input
 {
     /// <summary>
     /// Placeholder router for the new Input System. No-ops if the package is missing.

--- a/Assets/Scripts/Core/Mods/ModDiscovery.cs
+++ b/Assets/Scripts/Core/Mods/ModDiscovery.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-namespace Core.Mods
+namespace FantasyColony.Core.Mods
 {
     public class ModInfo
     {

--- a/Assets/Scripts/Core/Mods/XmlDefLoader.cs
+++ b/Assets/Scripts/Core/Mods/XmlDefLoader.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Xml.Linq;
 using UnityEngine;
 
-namespace Core.Mods
+namespace FantasyColony.Core.Mods
 {
     public class DefError
     {
@@ -18,7 +18,7 @@ namespace Core.Mods
     /// </summary>
     public static class XmlDefLoader
     {
-        public static void Load(List<ModInfo> mods, Core.Services.DefRegistry registry, List<DefError> errors)
+        public static void Load(List<ModInfo> mods, FantasyColony.Core.Services.DefRegistry registry, List<DefError> errors)
         {
             if (mods == null || registry == null) return;
             foreach (var mod in mods)

--- a/Assets/Scripts/Core/Services/AudioService.cs
+++ b/Assets/Scripts/Core/Services/AudioService.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     /// <summary>
     /// Lightweight audio bootstrap: one BGM source and one-shot SFX source.

--- a/Assets/Scripts/Core/Services/DefRegistry.cs
+++ b/Assets/Scripts/Core/Services/DefRegistry.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     /// <summary>
     /// Extremely simple definition registry keyed by type then id.

--- a/Assets/Scripts/Core/Services/JsonConfigService.cs
+++ b/Assets/Scripts/Core/Services/JsonConfigService.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     /// <summary>
     /// Minimal JSON-backed config service with string Get/Set to avoid API churn.

--- a/Assets/Scripts/Core/Services/JsonSaveService.cs
+++ b/Assets/Scripts/Core/Services/JsonSaveService.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     public struct SaveSlotMeta
     {

--- a/Assets/Scripts/Core/Services/LocService.cs
+++ b/Assets/Scripts/Core/Services/LocService.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Core.Services
+namespace FantasyColony.Core.Services
 {
     /// <summary>
     /// Minimal localization service. Loads Resources/Localization/{lang}/strings.json (TextAsset).


### PR DESCRIPTION
## Summary
- normalize new Core namespace to FantasyColony.Core.*
- fix BuildInfoRuntime to reference renamed namespace

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b443ce18288324b7cc4701da86613a