### PR TITLE
Refactor boot pipeline with modular tasks and restart helper

### DIFF
--- a/Assets/Scripts/Core/AppFlow.cs
+++ b/Assets/Scripts/Core/AppFlow.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+using UnityEngine;
+using FantasyColony.UI.Router;
+using FantasyColony.UI.Screens;
+
+namespace FantasyColony.Core {
+    /// <summary>
+    /// Centralized app-level flows (Restart, Quit) so buttons/screens don't need to know wiring.
+    /// </summary>
+    public class AppFlow : MonoBehaviour {
+        private UIRouter _router;
+        private ServiceRegistry _services;
+
+        public static AppFlow Instance { get; private set; }
+
+        private void Awake() {
+            if (Instance != null && Instance != this) {
+                Destroy(this);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        internal void Initialize(UIRouter router, ServiceRegistry services) {
+            _router = router;
+            _services = services;
+        }
+
+        /// <summary>
+        /// Cleanly restarts to the Boot screen, re-running the boot pipeline.
+        /// </summary>
+        public void Restart() {
+            if (_router == null) return;
+            StartCoroutine(RestartCo());
+        }
+
+        private IEnumerator RestartCo() {
+            // Cover with Boot screen first
+            _router.PopAll();
+            _router.Push<BootScreen>();
+
+            // Give UI one frame to present cover
+            yield return null;
+
+            // Free anything not referenced anymore
+            yield return Resources.UnloadUnusedAssets();
+            System.GC.Collect();
+        }
+
+        public void Quit() {
+            Application.Quit();
+        }
+    }
+}
+
+namespace FantasyColony.UI.Screens {
+    // Convenience shim to keep existing UI button bindings simple
+    public static class AppFlowCommands {
+        public static void Restart() => FantasyColony.Core.AppFlow.Instance?.Restart();
+        public static void Quit() => FantasyColony.Core.AppFlow.Instance?.Quit();
+    }
+}

--- a/Assets/Scripts/Core/AppFlow.cs.meta
+++ b/Assets/Scripts/Core/AppFlow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac475aee6fa44cdc9d657715368aae97
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/AppHost.cs
+++ b/Assets/Scripts/Core/AppHost.cs
@@ -17,16 +17,22 @@ using FCResourcesProvider = FantasyColony.Core.Services.ResourcesAssetProvider;
 namespace FantasyColony.Core
 {
     /// <summary>
-    /// Lifetime owner. Builds services, creates UIRoot and pushes Main Menu screen.
+    /// Lifetime owner.
+    /// Builds services, creates UIRoot and pushes Main Menu screen.
     /// </summary>
     public class AppHost : MonoBehaviour
     {
+        public static AppHost Instance { get; private set; }
+        public ServiceRegistry Services => _services;
+        public UIRouter Router => _router;
+
         private ServiceRegistry _services;
         private UIRoot _uiRoot;
         private UIRouter _router;
 
         private void Awake()
         {
+            Instance = this;
             Application.targetFrameRate = 60;
             QualitySettings.vSyncCount = 0;
 
@@ -41,6 +47,11 @@ namespace FantasyColony.Core
 
             // Router mounts screens under UIRoot
             _router = new UIRouter(_uiRoot.ScreenParent, _services);
+
+            // Attach AppFlow helper to manage restart/quit across the app
+            var flow = gameObject.GetComponent<AppFlow>();
+            if (flow == null) flow = gameObject.AddComponent<AppFlow>();
+            flow.Initialize(_router, _services);
 
             // Show Boot screen first so the UI covers while startup work initializes
             _router.Push<BootScreen>();

--- a/Assets/Scripts/Core/Services/AddressablesAssetProvider.cs
+++ b/Assets/Scripts/Core/Services/AddressablesAssetProvider.cs
@@ -1,0 +1,41 @@
+#if ADDRESSABLES
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+
+namespace FantasyColony.Core.Services {
+    /// <summary>
+    /// Optional Addressables-backed asset provider.
+    /// Compiles only when ADDRESSABLES define is present.
+    /// </summary>
+    public sealed class AddressablesAssetProvider : IAssetProvider {
+        private static bool _initialized;
+
+        public static void EnsureInitialized() {
+            if (_initialized) return;
+            try {
+                var h = Addressables.InitializeAsync();
+                h.WaitForCompletion();
+                _initialized = true;
+            } catch { /* swallow; fall back to on-demand */ }
+        }
+
+        public Sprite LoadSprite(string virtualPath) {
+            EnsureInitialized();
+            return LoadSync<Sprite>(virtualPath);
+        }
+
+        public AudioClip LoadAudio(string virtualPath) {
+            EnsureInitialized();
+            return LoadSync<AudioClip>(virtualPath);
+        }
+
+        private static T LoadSync<T>(string key) where T : UnityEngine.Object {
+            try {
+                AsyncOperationHandle<T> handle = Addressables.LoadAssetAsync<T>(key);
+                return handle.WaitForCompletion();
+            } catch { return null; }
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Core/Services/AddressablesAssetProvider.cs.meta
+++ b/Assets/Scripts/Core/Services/AddressablesAssetProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 637aebedd6554b87aabc71bb5977451a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- expose `AppHost` services/router and register `AppFlow` for restart/quit
- modularize boot pipeline with discrete tasks and reporting
- add optional Addressables asset provider for feature-flagged builds

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4498c790483249ede75e754b7c5e5