### PR TITLE
P2 fix: replace nonexistent Logger.Log with Debug.Log in MigrationEngine

### DIFF
--- a/Assets/Scripts/Core/Defs/Migrations/MigrationEngine.cs
+++ b/Assets/Scripts/Core/Defs/Migrations/MigrationEngine.cs
@@ -1,5 +1,6 @@
 using System;
 using FantasyColony.Core.Services;
+using UnityEngine;
 
 namespace FantasyColony.Core.Defs.Migrations {
     public static class MigrationEngine {
@@ -14,7 +15,7 @@ namespace FantasyColony.Core.Defs.Migrations {
                 if (m.SchemaVersion == 0) continue; // missing handled by validator; do not auto-set
                 if (m.SchemaVersion < current) {
                     migrated++;
-                    Logger.Log($"[Defs] Migrated {m.Type}.{m.Id} from v{m.SchemaVersion} to v{current}");
+                    Debug.Log($"[Defs] Migrated {m.Type}.{m.Id} from v{m.SchemaVersion} to v{current}");
                     // Future: data transforms on DOM; for now, we only log logical migration
                 }
             }


### PR DESCRIPTION
## Summary
- fix MigrationEngine to use Debug.Log instead of nonexistent Logger

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c1fe17f08324a142063713679d7b