### PR TITLE
Fix schema catalog to infer mod roots from DefIndex

### DIFF
--- a/Assets/Scripts/Boot/AppBootstrap.cs
+++ b/Assets/Scripts/Boot/AppBootstrap.cs
@@ -106,9 +106,9 @@ namespace FantasyColony.Boot {
             string warn = null;
             int warnCount = 0, migCount = 0;
             try {
-                // Ensure per-type schema catalog is loaded from StreamingAssets and Mods
-                FantasyColony.Core.Defs.Validation.SchemaCatalog.EnsureLoaded(ctx.Mods);
+                // Build index first, then load schemas from StreamingAssets and from each mod root inferred via index
                 var index = FantasyColony.Core.Defs.DefIndex.Build(ctx.Mods, ctx.Defs);
+                FantasyColony.Core.Defs.Validation.SchemaCatalog.EnsureLoadedFromIndex(index);
                 var results = FantasyColony.Core.Defs.Validation.DefValidator.Run(index);
                 foreach (var r in results) { Debug.LogWarning($"[Defs] {r}"); }
                 warnCount = results.Count;


### PR DESCRIPTION
## Summary
- build definition index first then load validation schemas inferred from it
- remove ModInfo dependency when loading mod schemas and search for schema directories based on def paths

## Testing
- `dotnet build Tools/XmlDefsTools/XmlDefsTools.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d22a58188324884663d920c7be19