### PR TITLE
Fix: add missing UI namespace

### DIFF
--- a/Assets/Scripts/UI/Screens/BootReportScreen.cs
+++ b/Assets/Scripts/UI/Screens/BootReportScreen.cs
@@ -2,6 +2,7 @@ using System.Text;
 using UnityEngine;
 using UnityEngine.UI;
 using FantasyColony.UI.Router;
+using FantasyColony.UI;
 
 namespace FantasyColony.UI.Screens {
     /// <summary>


### PR DESCRIPTION
## Summary
- add `using FantasyColony.UI` so `UIScreen` resolves in `BootReportScreen`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dbeec87c8324ba6193a4a50256a9