### PR TITLE
Enable F9 hotkey for Boot Report screen

### DIFF
--- a/Assets/Scripts/Core/AppHost.cs
+++ b/Assets/Scripts/Core/AppHost.cs
@@ -53,6 +53,10 @@ namespace FantasyColony.Core
             if (flow == null) flow = gameObject.AddComponent<AppFlow>();
             flow.Initialize(_router, _services);
 
+            // Global shortcuts (e.g., F9 to open Boot Report) available in all builds
+            var shortcuts = gameObject.GetComponent<GlobalShortcuts>();
+            if (shortcuts == null) shortcuts = gameObject.AddComponent<GlobalShortcuts>();
+
             // Show Boot screen first so the UI covers while startup work initializes
             _router.Push<BootScreen>();
         }

--- a/Assets/Scripts/Core/GlobalShortcuts.cs
+++ b/Assets/Scripts/Core/GlobalShortcuts.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+using FantasyColony.UI.Router;
+using FantasyColony.UI.Screens;
+
+namespace FantasyColony.Core {
+    /// <summary>
+    /// Lightweight global hotkeys available in all builds.
+    /// Currently: F9 opens the Boot Report screen.
+    /// </summary>
+    public sealed class GlobalShortcuts : MonoBehaviour {
+        private void Awake() {
+            // Attach to AppHost GameObject; keep across restarts
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void Update() {
+            // Open Boot Report
+            if (Input.GetKeyDown(KeyCode.F9)) {
+                var router = UIRouter.Current;
+                if (router == null) {
+                    // Fallback if static Current isn't set yet
+                    var host = AppHost.Instance;
+                    router = host != null ? host.Router : null;
+                }
+                router?.Push<BootReportScreen>();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Core/GlobalShortcuts.cs.meta
+++ b/Assets/Scripts/Core/GlobalShortcuts.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cec2b6007add4424a1e3d76fd4105d81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- attach `GlobalShortcuts` to `AppHost` for global hotkeys
- press F9 to open `BootReportScreen`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e207ce648324b76d9da10a7dbde8