### PR TITLE
Fix namespace collision: use UnityEngine.Input via alias in GlobalShortcuts

### DIFF
--- a/Assets/Scripts/Core/GlobalShortcuts.cs
+++ b/Assets/Scripts/Core/GlobalShortcuts.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using FantasyColony.UI.Router;
 using FantasyColony.UI.Screens;
+using UInput = UnityEngine.Input;
 
 namespace FantasyColony.Core {
     /// <summary>
@@ -15,7 +16,7 @@ namespace FantasyColony.Core {
 
         private void Update() {
             // Open Boot Report
-            if (Input.GetKeyDown(KeyCode.F9)) {
+            if (UInput.GetKeyDown(KeyCode.F9)) {
                 var router = UIRouter.Current;
                 if (router == null) {
                     // Fallback if static Current isn't set yet


### PR DESCRIPTION
## Summary
- resolve namespace collision by aliasing UnityEngine.Input
- update shortcut handler to use UInput alias for F9 Boot Report

## Testing
- `dotnet test Tools/XmlDefsTools/XmlDefsTools.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e3e236e4832488c1cc7616befb44