### PR TITLE
Support Input System for F9 global shortcut

### DIFF
--- a/Assets/Scripts/Core/GlobalShortcuts.cs
+++ b/Assets/Scripts/Core/GlobalShortcuts.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 using FantasyColony.UI.Router;
 using FantasyColony.UI.Screens;
 using UInput = UnityEngine.Input;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 namespace FantasyColony.Core {
     /// <summary>
@@ -16,14 +19,22 @@ namespace FantasyColony.Core {
 
         private void Update() {
             // Open Boot Report
-            if (UInput.GetKeyDown(KeyCode.F9)) {
+            bool pressed = UInput.GetKeyDown(KeyCode.F9);
+#if ENABLE_INPUT_SYSTEM
+            if (!pressed) {
+                var kb = Keyboard.current;
+                if (kb != null && kb.f9Key.wasPressedThisFrame) pressed = true;
+            }
+#endif
+            if (pressed) {
                 var router = UIRouter.Current;
                 if (router == null) {
                     // Fallback if static Current isn't set yet
                     var host = AppHost.Instance;
                     router = host != null ? host.Router : null;
                 }
-                router?.Push<BootReportScreen>();
+                if (router != null) router.Push<BootReportScreen>();
+                else Debug.LogWarning("[GlobalShortcuts] No UIRouter available to open Boot Report.");
             }
         }
     }


### PR DESCRIPTION
## Summary
- handle F9 using the new Input System in GlobalShortcuts
- warn when Boot Report shortcut is used without a UIRouter

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e6a990a883249967056cdff655a8