### PR TITLE
Bootstrap: guard duplication and prefer vSync pacing

### DIFF
--- a/Assets/Scripts/Core/AppBootstrap.cs
+++ b/Assets/Scripts/Core/AppBootstrap.cs
@@ -7,9 +7,15 @@ namespace FantasyColony.Core
     /// </summary>
     public static class AppBootstrap
     {
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Boot()
         {
+            // Guard against duplicates (domain reloads, additive loads)
+#if UNITY_2023_1_OR_NEWER
+            if (Object.FindFirstObjectByType<AppHost>() != null) return;
+#else
+            if (Object.FindObjectOfType<AppHost>() != null) return;
+#endif
             // Root host object that survives for the whole app lifetime.
             var root = new GameObject("AppRoot");
             Object.DontDestroyOnLoad(root);

--- a/Assets/Scripts/Core/AppHost.cs
+++ b/Assets/Scripts/Core/AppHost.cs
@@ -33,8 +33,9 @@ namespace FantasyColony.Core
         private void Awake()
         {
             Instance = this;
-            Application.targetFrameRate = 60;
-            QualitySettings.vSyncCount = 0;
+            QualitySettings.vSyncCount = 1;
+            // On desktop, let vSync drive frame pacing. Leave targetFrameRate unset (-1) unless vSync is disabled.
+            Application.targetFrameRate = -1;
 
             _services = new ServiceRegistry();
             _services.Register<FCLogger>(new FCFileLogger());


### PR DESCRIPTION
## Summary
- boot AppHost before scene load and prevent duplicates
- rely on vSync for desktop frame pacing and leave targetFrameRate unset

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f828ffa48324a6a3ce01adb2a5d4