### PR TITLE
Core hardening and boot diagnostics improvements

### DIFF
--- a/Assets/Scripts/Core/AppHost.cs
+++ b/Assets/Scripts/Core/AppHost.cs
@@ -33,8 +33,8 @@ namespace FantasyColony.Core
         private void Awake()
         {
             Instance = this;
+            // Frame pacing is controlled via vSync for desktop builds.
             QualitySettings.vSyncCount = 1;
-            // On desktop, let vSync drive frame pacing. Leave targetFrameRate unset (-1) unless vSync is disabled.
             Application.targetFrameRate = -1;
 
             _services = new ServiceRegistry();
@@ -42,6 +42,8 @@ namespace FantasyColony.Core
             _services.Register<FCConfigService>(new FCDummyConfig());
             _services.Register<FCEventBus>(new FCSimpleEventBus());
             _services.Register<FCAssetProvider>(new FCResourcesProvider());
+            // Make AudioService discoverable via the registry
+            _services.Register<AudioService>(AudioService.Instance);
 
             // Create UI root (Canvas + EventSystem)
             _uiRoot = UIRoot.Create(transform);

--- a/Assets/Scripts/Core/ServiceRegistry.cs
+++ b/Assets/Scripts/Core/ServiceRegistry.cs
@@ -18,5 +18,29 @@ namespace FantasyColony.Core
                 return t;
             throw new InvalidOperationException($"Service not registered: {typeof(T).Name}");
         }
+
+        /// <summary>
+        /// Non-throwing lookup for fail-soft flows (player builds).
+        /// </summary>
+        public bool TryGet<T>(out T service) where T : class
+        {
+            if (_map.TryGetValue(typeof(T), out var o) && o is T t)
+            {
+                service = t;
+                return true;
+            }
+            service = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if a service of type T is registered.
+        /// </summary>
+        public bool Has<T>() where T : class => _map.ContainsKey(typeof(T));
+
+        /// <summary>
+        /// Optional unregistration helper. Returns true if removed.
+        /// </summary>
+        public bool Unregister<T>() where T : class => _map.Remove(typeof(T));
     }
 }

--- a/Assets/Scripts/Core/Services/AddressablesAssetProvider.cs
+++ b/Assets/Scripts/Core/Services/AddressablesAssetProvider.cs
@@ -15,9 +15,8 @@ namespace FantasyColony.Core.Services {
             if (_initialized) return;
             try {
                 var h = Addressables.InitializeAsync();
-                h.WaitForCompletion();
-                _initialized = true;
-            } catch { /* swallow; fall back to on-demand */ }
+                h.Completed += _ => { _initialized = true; };
+            } catch { /* swallow; fail-soft */ }
         }
 
         public Sprite LoadSprite(string virtualPath) {

--- a/Assets/Scripts/Core/Services/AudioService.cs
+++ b/Assets/Scripts/Core/Services/AudioService.cs
@@ -31,6 +31,14 @@ namespace FantasyColony.Core.Services
 
         private void Awake()
         {
+            // Duplicate guard: prefer the first instance
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            _instance = this;
+
             _bgm = gameObject.AddComponent<AudioSource>();
             _bgm.loop = true;
             _bgm.playOnAwake = false;

--- a/Assets/Scripts/Core/Services/DefRegistry.cs
+++ b/Assets/Scripts/Core/Services/DefRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace FantasyColony.Core.Services {
     /// <summary>
@@ -19,6 +20,7 @@ namespace FantasyColony.Core.Services {
         private readonly Dictionary<string, Dictionary<string, Entry>> _map = new(StringComparer.OrdinalIgnoreCase);
 
         public int Count { get; private set; }
+        public int ConflictCount { get; private set; }
 
         public void Register(string type, string id, string filePath, string modId) {
             if (string.IsNullOrEmpty(type) || string.IsNullOrEmpty(id)) return;
@@ -26,9 +28,12 @@ namespace FantasyColony.Core.Services {
                 inner = new Dictionary<string, Entry>(StringComparer.OrdinalIgnoreCase);
                 _map[type] = inner;
             }
-            var isNew = !inner.ContainsKey(id);
+            if (inner.TryGetValue(id, out var existing)) {
+                ConflictCount++;
+                Debug.LogWarning($"[Defs] Conflict for {type}/{id}: {existing.ModId} -> {modId} (file: {filePath})");
+            }
+            else { Count++; }
             inner[id] = new Entry { Type = type, Id = id, Path = filePath ?? string.Empty, ModId = modId };
-            if (isNew) Count++;
         }
 
         // Legacy Add signature for backward compatibility


### PR DESCRIPTION
## Summary
- add non-throwing lookup and management helpers to `ServiceRegistry`
- detect and report definition conflicts and surface them in boot report
- guard `AudioService` against duplicates and register it in `AppHost`
- warm Addressables during boot and make initialization async

## Testing
- ⚠️ `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fb362608832488452d5b614567cb