### PR TITLE
Integrate JsonConfigService & TextAsset support across services

### DIFF
--- a/Assets/Scripts/Core/Services/AddressablesAssetProvider.cs
+++ b/Assets/Scripts/Core/Services/AddressablesAssetProvider.cs
@@ -29,6 +29,11 @@ namespace FantasyColony.Core.Services {
             return LoadSync<AudioClip>(virtualPath);
         }
 
+        public TextAsset LoadText(string virtualPath) {
+            EnsureInitialized();
+            return LoadSync<TextAsset>(virtualPath);
+        }
+
         private static T LoadSync<T>(string key) where T : UnityEngine.Object {
             try {
                 AsyncOperationHandle<T> handle = Addressables.LoadAssetAsync<T>(key);

--- a/Assets/Scripts/Core/Services/IAssetProvider.cs
+++ b/Assets/Scripts/Core/Services/IAssetProvider.cs
@@ -6,6 +6,7 @@ namespace FantasyColony.Core.Services
     {
         Sprite LoadSprite(string virtualPath);
         AudioClip LoadAudio(string virtualPath);
+        TextAsset LoadText(string virtualPath);
     }
 
     public sealed class ResourcesAssetProvider : IAssetProvider
@@ -18,6 +19,11 @@ namespace FantasyColony.Core.Services
         public AudioClip LoadAudio(string virtualPath)
         {
             return Resources.Load<AudioClip>(virtualPath);
+        }
+
+        public TextAsset LoadText(string virtualPath)
+        {
+            return Resources.Load<TextAsset>(virtualPath);
         }
     }
 }

--- a/Assets/Scripts/Core/Services/LocService.cs
+++ b/Assets/Scripts/Core/Services/LocService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using FantasyColony.Core;
 
 namespace FantasyColony.Core.Services
 {
@@ -47,7 +48,18 @@ namespace FantasyColony.Core.Services
             try
             {
                 var path = $"Localization/{lang}/strings";
-                var ta = Resources.Load<TextAsset>(path);
+                TextAsset ta = null;
+                // Prefer provider if available (mod- and backend-friendly)
+                var host = AppHost.Instance;
+                if (host != null && host.Services != null && host.Services.TryGet<IAssetProvider>(out var provider))
+                {
+                    ta = provider.LoadText(path);
+                }
+                // Fallback to Resources for safety
+                if (ta == null)
+                {
+                    ta = Resources.Load<TextAsset>(path);
+                }
                 if (ta == null) return false;
                 var bag = JsonUtility.FromJson<LocBag>(ta.text);
                 if (bag?.entries != null)


### PR DESCRIPTION
## Summary
- guard against duplicate AppHost instances and drive frame pacing from JsonConfigService
- expose TextAsset loading through IAssetProvider (Resources and Addressables)
- LocService now uses the asset provider before falling back to Resources
- JsonConfigService implements IConfigService and saves atomically

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ff41493483249c4f36a4b95ca4df