### PR TITLE
Fix: remove .Value from TintTheme usage (was non-nullable after coalesce)

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -133,7 +133,7 @@ namespace FantasyColony.UI.Widgets
                 fillImg.type = Image.Type.Tiled;
             }
             var panelTheme = theme ?? BaseUIStyle.SecondaryTheme;
-            fillImg.color = panelTheme.Value.Base;
+            fillImg.color = panelTheme.Base;
 
             // --- Border (9-slice) as sibling ABOVE fill ---
             var borderGO = new GameObject("BG_Border", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(LayoutElement));


### PR DESCRIPTION
## Summary
- Fix panel theme color application by removing redundant `.Value` access after null-coalescing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b522f94530832480efec1afaee4b32