### PR TITLE
Use pixel units for UIFrame border and add grayscale tint shader for wood fills

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -11,6 +11,7 @@ namespace FantasyColony.UI.Widgets
     {
         // Cache a symmetrized version of the dark 9-slice border so L/R and T/B are equal.
         private static Sprite _darkBorderSymmetric;
+        private static Material _grayscaleTintMat;
 
         // Ensure the 9-slice border has equal left/right and top/bottom edge sizes.
         // This avoids visual asymmetry when Unity stretches the sliced edges.
@@ -25,6 +26,17 @@ namespace FantasyColony.UI.Widgets
 
             _darkBorderSymmetric = MakeUniformBorderFromTopBottom(src);
             return _darkBorderSymmetric;
+        }
+
+        private static Material GetGrayscaleTintMaterial()
+        {
+            if (_grayscaleTintMat != null) return _grayscaleTintMat;
+            var sh = Shader.Find("UI/GrayscaleTint");
+            if (sh != null)
+            {
+                _grayscaleTintMat = new Material(sh);
+            }
+            return _grayscaleTintMat;
         }
 
         private static Sprite MakeUniformBorderFromTopBottom(Sprite src)
@@ -132,6 +144,8 @@ namespace FantasyColony.UI.Widgets
                 fillImg.sprite = wood;
                 fillImg.type = Image.Type.Tiled;
             }
+            var mat = GetGrayscaleTintMaterial();
+            if (mat != null) fillImg.material = mat;
             var panelTheme = theme ?? BaseUIStyle.SecondaryTheme;
             fillImg.color = panelTheme.Base;
             // --- Pixel-precise frame instead of 9-slice Image ---
@@ -197,6 +211,8 @@ namespace FantasyColony.UI.Widgets
                 fillImg.sprite = wood;
                 fillImg.type = Image.Type.Tiled;
             }
+            var mat = GetGrayscaleTintMaterial();
+            if (mat != null) fillImg.material = mat;
             fillImg.color = theme.Base; // tint the wood itself
             // --- Pixel-precise frame instead of 9-slice Image ---
             var borderGO = new GameObject("Frame", typeof(RectTransform), typeof(CanvasRenderer), typeof(LayoutElement), typeof(UIFrame));

--- a/Assets/Scripts/UI/Widgets/UIFrame.cs
+++ b/Assets/Scripts/UI/Widgets/UIFrame.cs
@@ -11,7 +11,7 @@ namespace FantasyColony.UI.Widgets
     public class UIFrame : MonoBehaviour
     {
         [SerializeField] private Sprite _sourceNineSlice; // your dark border 9-slice
-        [SerializeField] private float _targetBorderPx = 1f;
+        [SerializeField] private float _targetBorderPx = 1f; // in screen pixels
         [SerializeField] private Color _tint = Color.white;
 
         // child images
@@ -89,21 +89,12 @@ namespace FantasyColony.UI.Widgets
             _top.preserveAspect = _bottom.preserveAspect = _left.preserveAspect = _right.preserveAspect = false;
         }
 
-        float PixelsToUnits(float px)
-        {
-            if (_canvas == null) _canvas = GetComponentInParent<Canvas>();
-            float refPPU = (_canvas != null && _canvas.referencePixelsPerUnit > 0f) ? _canvas.referencePixelsPerUnit : 100f;
-            float scale = (_canvas != null && _canvas.scaleFactor > 0f) ? _canvas.scaleFactor : 1f;
-            return px / (refPPU * scale);
-        }
-
         void LayoutNow()
         {
             if (_rt == null) _rt = GetComponent<RectTransform>();
             if (_rt == null || _top == null) return;
 
-            float t = Mathf.Max(0.0f, _targetBorderPx);
-            float u = PixelsToUnits(t);
+            float px = Mathf.Max(0.0f, _targetBorderPx);
 
             // Top
             var trt = _top.rectTransform;
@@ -111,7 +102,7 @@ namespace FantasyColony.UI.Widgets
             trt.anchorMax = new Vector2(1f, 1f);
             trt.pivot = new Vector2(0.5f, 1f);
             trt.anchoredPosition = Vector2.zero;
-            trt.sizeDelta = new Vector2(0f, u);
+            trt.sizeDelta = new Vector2(0f, Mathf.Round(px));
 
             // Bottom
             var brt = _bottom.rectTransform;
@@ -119,7 +110,7 @@ namespace FantasyColony.UI.Widgets
             brt.anchorMax = new Vector2(1f, 0f);
             brt.pivot = new Vector2(0.5f, 0f);
             brt.anchoredPosition = Vector2.zero;
-            brt.sizeDelta = new Vector2(0f, u);
+            brt.sizeDelta = new Vector2(0f, Mathf.Round(px));
 
             // Left
             var lrt = _left.rectTransform;
@@ -127,7 +118,7 @@ namespace FantasyColony.UI.Widgets
             lrt.anchorMax = new Vector2(0f, 1f);
             lrt.pivot = new Vector2(0f, 0.5f);
             lrt.anchoredPosition = Vector2.zero;
-            lrt.sizeDelta = new Vector2(u, 0f);
+            lrt.sizeDelta = new Vector2(Mathf.Round(px), 0f);
 
             // Right
             var rrt = _right.rectTransform;
@@ -135,7 +126,7 @@ namespace FantasyColony.UI.Widgets
             rrt.anchorMax = new Vector2(1f, 1f);
             rrt.pivot = new Vector2(1f, 0.5f);
             rrt.anchoredPosition = Vector2.zero;
-            rrt.sizeDelta = new Vector2(u, 0f);
+            rrt.sizeDelta = new Vector2(Mathf.Round(px), 0f);
         }
     }
 }

--- a/Assets/Shaders/UIGrayscaleTint.shader
+++ b/Assets/Shaders/UIGrayscaleTint.shader
@@ -1,0 +1,77 @@
+Shader "UI/GrayscaleTint"
+{
+    Properties
+    {
+        [PerRendererData] _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
+    }
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent"
+            "IgnoreProjector" = "True"
+            "RenderType" = "Transparent"
+            "PreviewType" = "Plane"
+            "CanUseSpriteAtlas" = "True"
+        }
+
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Stencil
+        {
+            Ref 0
+            Comp Always
+            Pass Keep
+        }
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex   : POSITION;
+                float4 color    : COLOR;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex   : SV_POSITION;
+                fixed4 color    : COLOR;
+                half2 texcoord  : TEXCOORD0;
+            };
+
+            fixed4 _Color;
+            sampler2D _MainTex;
+
+            v2f vert (appdata_t IN)
+            {
+                v2f OUT;
+                OUT.vertex = UnityObjectToClipPos(IN.vertex);
+                OUT.texcoord = IN.texcoord;
+                OUT.color = IN.color;
+                return OUT;
+            }
+
+            fixed4 frag (v2f IN) : SV_Target
+            {
+                fixed4 c = tex2D(_MainTex, IN.texcoord) * IN.color;
+                // luminance
+                fixed g = dot(c.rgb, fixed3(0.299, 0.587, 0.114));
+                fixed3 gray = fixed3(g, g, g);
+                fixed3 tinted = gray * _Color.rgb;
+                return fixed4(tinted, c.a * _Color.a);
+            }
+            ENDCG
+        }
+    }
+}
+

--- a/Assets/Shaders/UIGrayscaleTint.shader.meta
+++ b/Assets/Shaders/UIGrayscaleTint.shader.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 431b1451ce5c464ab10da753c9941888
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorConfig:
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+


### PR DESCRIPTION
## Summary
- use screen pixels for UIFrame border thickness
- add UI/GrayscaleTint shader and apply to panel/button wood textures
- tint wood fills consistently via cached material

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b52958634c83248712047eddd755a9