### PR TITLE
UI: grayscale shader improvements and border default

### DIFF
--- a/Assets/Scripts/UI/Style/BaseUIStyle.cs
+++ b/Assets/Scripts/UI/Style/BaseUIStyle.cs
@@ -31,7 +31,7 @@ namespace FantasyColony.UI.Style
 
         // Desired on-screen border thickness in device pixels for sliced borders
         // This single value controls both panels and buttons.
-        public const float TargetBorderPx = 10f; // try 0.75f for subtler, 2f for thicker
+        public const float TargetBorderPx = 10f; // default visual = 10px borders
 
         // --- Tint themes for wood_soft_tile surfaces ---
         public struct TintTheme { public Color32 Base, Hover, Pressed; }

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -35,6 +35,7 @@ namespace FantasyColony.UI.Widgets
             if (sh != null)
             {
                 _grayscaleTintMat = new Material(sh);
+                _grayscaleTintMat.hideFlags = HideFlags.DontSaveInBuild | HideFlags.DontSaveInEditor;
             }
             return _grayscaleTintMat;
         }

--- a/Assets/Shaders/UIGrayscaleTint.shader
+++ b/Assets/Shaders/UIGrayscaleTint.shader
@@ -4,6 +4,13 @@ Shader "UI/GrayscaleTint"
     {
         [PerRendererData] _MainTex ("Sprite Texture", 2D) = "white" {}
         _Color ("Tint", Color) = (1,1,1,1)
+        [HideInInspector] _StencilComp ("Stencil Comparison", Float) = 8
+        [HideInInspector] _Stencil ("Stencil ID", Float) = 0
+        [HideInInspector] _StencilOp ("Stencil Operation", Float) = 0
+        [HideInInspector] _StencilWriteMask ("Stencil Write Mask", Float) = 255
+        [HideInInspector] _StencilReadMask ("Stencil Read Mask", Float) = 255
+        [HideInInspector] _ColorMask ("Color Mask", Float) = 15
+        [Toggle(UNITY_UI_ALPHACLIP)] _UseUIAlphaClip ("Use Alpha Clip", Float) = 0
     }
     SubShader
     {
@@ -23,9 +30,11 @@ Shader "UI/GrayscaleTint"
 
         Stencil
         {
-            Ref 0
-            Comp Always
-            Pass Keep
+            Ref [_Stencil]
+            Comp [_StencilComp]
+            Pass [_StencilOp]
+            ReadMask [_StencilReadMask]
+            WriteMask [_StencilWriteMask]
         }
 
         Pass
@@ -33,7 +42,13 @@ Shader "UI/GrayscaleTint"
             CGPROGRAM
             #pragma vertex vert
             #pragma fragment frag
+            #pragma target 2.0
             #include "UnityCG.cginc"
+            #include "UnityUI.cginc"
+
+            #pragma multi_compile __ UNITY_UI_CLIP_RECT
+            #pragma multi_compile __ UNITY_UI_ALPHACLIP
+            #pragma multi_compile __ UNITY_UI_ETC1_EXTERNAL_ALPHA
 
             struct appdata_t
             {
@@ -47,28 +62,51 @@ Shader "UI/GrayscaleTint"
                 float4 vertex   : SV_POSITION;
                 fixed4 color    : COLOR;
                 half2 texcoord  : TEXCOORD0;
+                float4 worldPos : TEXCOORD1;
             };
 
             fixed4 _Color;
             sampler2D _MainTex;
+            float4 _ClipRect;
 
             v2f vert (appdata_t IN)
             {
                 v2f OUT;
+                OUT.worldPos = IN.vertex;
                 OUT.vertex = UnityObjectToClipPos(IN.vertex);
                 OUT.texcoord = IN.texcoord;
                 OUT.color = IN.color;
                 return OUT;
             }
 
+            fixed4 SampleSpriteTexture(half2 uv)
+            {
+                fixed4 color = tex2D(_MainTex, uv);
+                #ifdef UNITY_UI_ETC1_EXTERNAL_ALPHA
+                fixed4 alpha = tex2D(_AlphaTex, uv);
+                color.a = alpha.r;
+                #endif
+                return color;
+            }
+
             fixed4 frag (v2f IN) : SV_Target
             {
-                fixed4 c = tex2D(_MainTex, IN.texcoord) * IN.color;
-                // luminance
+                fixed4 c = SampleSpriteTexture(IN.texcoord) * IN.color;
+
+                // grayscale luminance
                 fixed g = dot(c.rgb, fixed3(0.299, 0.587, 0.114));
-                fixed3 gray = fixed3(g, g, g);
-                fixed3 tinted = gray * _Color.rgb;
-                return fixed4(tinted, c.a * _Color.a);
+                fixed3 tinted = g * _Color.rgb;
+                fixed4 outCol = fixed4(tinted, c.a * _Color.a);
+
+                #ifdef UNITY_UI_CLIP_RECT
+                outCol.a *= UnityGet2DClipping(IN.worldPos.xy, _ClipRect);
+                #endif
+
+                #ifdef UNITY_UI_ALPHACLIP
+                clip (outCol.a - 0.001);
+                #endif
+
+                return outCol;
             }
             ENDCG
         }


### PR DESCRIPTION
## Summary
- update grayscale tint shader with stencil, clipping, atlas support for full Unity UI compatibility
- use 10px default border thickness for sliced UI elements
- avoid saving grayscale tint material in builds/editor

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b53091e36483248bccc0a0fe394117