### PR TITLE
Adjust UI tint shader and button themes

### DIFF
--- a/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -39,14 +39,14 @@ namespace FantasyColony.UI.Screens
             void NotImpl(string name) => Debug.Log($"BUTTON: {name} (not implemented)");
 
             UIFactory.CreateButtonSecondary(panel, "Log",        DevLogOverlay.Show);
-            UIFactory.CreateButtonPrimary(panel,   "Start",      () => NotImpl("Start"));
+            var startBtn = UIFactory.CreateButtonPrimary(panel, "Start", () => NotImpl("Start"));
             var btnContinue = UIFactory.CreateButtonSecondary(panel, "Continue", () => NotImpl("Continue"));
             var btnLoad     = UIFactory.CreateButtonSecondary(panel, "Load",     () => NotImpl("Load"));
             UIFactory.CreateButtonSecondary(panel, "Options",    () => NotImpl("Options"));
             UIFactory.CreateButtonSecondary(panel, "Mods",       () => NotImpl("Mods"));
             UIFactory.CreateButtonSecondary(panel, "Creator",    () => NotImpl("Creator"));
             UIFactory.CreateButtonSecondary(panel, "Restart",    ShowRestartConfirm);
-            UIFactory.CreateButtonDanger(panel,     "Quit",      ShowQuitConfirm);
+            var quitBtn = UIFactory.CreateButtonDanger(panel, "Quit", ShowQuitConfirm);
 
 #if UNITY_EDITOR || DEVELOPMENT_BUILD
             UIFactory.CreateButtonSecondary(panel, "Boot Report", () => UIRouter.Current?.Push<BootReportScreen>());

--- a/Assets/Shaders/UIGrayscaleTint.shader
+++ b/Assets/Shaders/UIGrayscaleTint.shader
@@ -91,12 +91,16 @@ Shader "UI/GrayscaleTint"
 
             fixed4 frag (v2f IN) : SV_Target
             {
-                fixed4 c = SampleSpriteTexture(IN.texcoord) * IN.color;
+                // sample wood texture (do NOT premultiply by vertex color)
+                fixed4 tex = SampleSpriteTexture(IN.texcoord);
 
-                // grayscale luminance
-                fixed g = dot(c.rgb, fixed3(0.299, 0.587, 0.114));
-                fixed3 tinted = g * _Color.rgb;
-                fixed4 outCol = fixed4(tinted, c.a * _Color.a);
+                // grayscale from texture only (preserve detail, neutralize hue)
+                fixed g = dot(tex.rgb, fixed3(0.299, 0.587, 0.114));
+
+                // use UI vertex color as the tint source (Button/Graphic color)
+                fixed3 tinted = g * IN.color.rgb;
+                fixed a = tex.a * IN.color.a;
+                fixed4 outCol = fixed4(tinted, a);
 
                 #ifdef UNITY_UI_CLIP_RECT
                 outCol.a *= UnityGet2DClipping(IN.worldPos.xy, _ClipRect);


### PR DESCRIPTION
## Summary
- Tint shader now derives grayscale from texture then applies vertex color tint
- Main menu Start and Quit buttons now explicitly reference their themed button helpers

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b533c723b08324958752d6634c3950