### PR TITLE
Fix grayscale tint material application and toggle

### DIFF
--- a/Assets/Scripts/UI/Style/BaseUIStyle.cs
+++ b/Assets/Scripts/UI/Style/BaseUIStyle.cs
@@ -30,7 +30,7 @@ namespace FantasyColony.UI.Style
         public const string DarkBorder9SPath = "ui/sprites/9slice/border_dark_9s";
 
         // Toggle: grayscale the wood tile before tinting (for faithful palette hues)
-        public const bool UseGrayscaleTint = true;
+        public static bool UseGrayscaleTint = true; // static (not const) to avoid unreachable-code folding
 
         // Desired on-screen border thickness in device pixels for sliced borders
         // This single value controls both panels and buttons.

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -1,9 +1,9 @@
 using UnityEngine;
 using UnityEngine.UI;
-using FantasyColony.UI.Style;
 using System;
+using FantasyColony; // for GetHierarchyPath()
+using FantasyColony.UI.Style;
 using FantasyColony.UI.Util;
-using FantasyColony; // for Transform.GetHierarchyPath extension
 using TintTheme = FantasyColony.UI.Style.BaseUIStyle.TintTheme;
 
 namespace FantasyColony.UI.Widgets
@@ -52,9 +52,7 @@ namespace FantasyColony.UI.Widgets
                 return; // use default
             var mat = GetGrayscaleTintMaterial();
             if (mat == null) return;
-            // assign both to avoid fallback in some batching paths
             img.material = mat;
-            img.sharedMaterial = mat;
             img.SetMaterialDirty();
 #if UNITY_EDITOR
             // Verify what actually renders


### PR DESCRIPTION
## Summary
- allow runtime toggling of wood tinting by making `UseGrayscaleTint` static
- remove `sharedMaterial` assignment and call `SetMaterialDirty` when applying grayscale tint material

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b53a3c378c8324b688cb4f17f90a4d