### PR TITLE
Fix wood texture resource path for UI panels and buttons

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -174,9 +174,9 @@ namespace FantasyColony.UI.Widgets
             fillImg.raycastTarget = false;
             var le = fillGO.GetComponent<LayoutElement>();
             le.ignoreLayout = true;
-            var wood = Resources.Load<Sprite>("ui/sprites/tiles/wood_soft_tile");
+            var wood = Resources.Load<Sprite>(BaseUIStyle.WoodTilePath);
             if (wood == null)
-                Debug.LogWarning($"UIFactory: Wood tile sprite missing at ui/sprites/tiles/wood_soft_tile for {fillGO.transform.GetHierarchyPath()}");
+                Debug.LogWarning($"UIFactory: Wood tile sprite missing at {BaseUIStyle.WoodTilePath} for {fillGO.transform.GetHierarchyPath()}");
             fillImg.sprite = wood;
             fillImg.type = Image.Type.Tiled;
             fillImg.preserveAspect = false;
@@ -240,9 +240,9 @@ namespace FantasyColony.UI.Widgets
             fillImg.raycastTarget = false;
             fillImg.preserveAspect = false;
             fillGO.GetComponent<LayoutElement>().ignoreLayout = true;
-            var wood = Resources.Load<Sprite>("ui/sprites/tiles/wood_soft_tile");
+            var wood = Resources.Load<Sprite>(BaseUIStyle.WoodTilePath);
             if (wood == null)
-                Debug.LogWarning($"UIFactory: Wood tile sprite missing at ui/sprites/tiles/wood_soft_tile for {fillGO.transform.GetHierarchyPath()}");
+                Debug.LogWarning($"UIFactory: Wood tile sprite missing at {BaseUIStyle.WoodTilePath} for {fillGO.transform.GetHierarchyPath()}");
             fillImg.sprite = wood;
             fillImg.type = Image.Type.Tiled;
             ApplyTintMaterial(fillImg);


### PR DESCRIPTION
## Summary
- Load wood tile sprite via `BaseUIStyle.WoodTilePath` in `UIFactory`
- Keep `BaseUIStyle.WoodTilePath` constant as `ui/sprites/tile/wood_soft_tile`

## Testing
- `dotnet build Tools/XmlDefsTools/XmlDefsTools.csproj` *(fails: command not found)*
- `Unity -batchmode -quit -projectPath . -executeMethod SomeMethod` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b543246a5883248e0b426cc1139432