### PR TITLE
Fix missing IScreen reference in ModsScreen

### DIFF
--- a/Assets/Scripts/UI/Screens/ModsScreen.cs
+++ b/Assets/Scripts/UI/Screens/ModsScreen.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
-using FantasyColony.UI; // IScreen
+using FantasyColony.UI.Router; // IScreen
 
 namespace FantasyColony.UI.Screens
 {


### PR DESCRIPTION
## Summary
- import IScreen from the correct namespace in ModsScreen

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b54e40f64c83248f45550256d624b9