### PR TITLE
Fix build error in ModsScreen foldout

### DIFF
--- a/Assets/Scripts/UI/Screens/ModsScreen.cs
+++ b/Assets/Scripts/UI/Screens/ModsScreen.cs
@@ -400,6 +400,7 @@ namespace FantasyColony.UI.Screens
 
             // Content
             content = CreatePanelSurface(parent, title + "_Content");
+            var localContent = content;
             var vl = content.gameObject.AddComponent<VerticalLayoutGroup>();
             vl.childControlWidth = true;
             vl.childControlHeight = false;
@@ -415,7 +416,7 @@ namespace FantasyColony.UI.Screens
             btn.onClick.AddListener(() =>
             {
                 expanded = !expanded;
-                content.gameObject.SetActive(expanded);
+                localContent.gameObject.SetActive(expanded);
                 plusMinus.text = expanded ? "–" : "+";
             });
         }


### PR DESCRIPTION
## Summary
- avoid capturing out parameter in ModsScreen foldout listener

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5507a6f3883248534ba355f092f66