### PR TITLE
Fix UIFrame border thickness scaling

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFrame.cs
+++ b/Assets/Scripts/UI/Widgets/UIFrame.cs
@@ -100,11 +100,11 @@ namespace FantasyColony.UI.Widgets
 
             float px = Mathf.Max(0.0f, _targetBorderPx);
             if (_canvas == null) _canvas = GetComponentInParent<Canvas>();
-            float refPPU = (_canvas != null && _canvas.referencePixelsPerUnit > 0f) ? _canvas.referencePixelsPerUnit : 100f;
             float sf = (_canvas != null && _canvas.scaleFactor > 0f) ? _canvas.scaleFactor : 1f;
-            // Convert requested pixel thickness to local UI units so thickness is pixel-accurate across scalers.
-            float unitsPerPixel = 1f / (refPPU * sf);
-            float u = Mathf.Round(px) * unitsPerPixel;
+            // RectTransform sizes are specified in reference pixels. Under CanvasScaler.ScaleWithScreenSize,
+            // device pixels = reference pixels * scaleFactor. Therefore to get N device pixels of thickness,
+            // we set sizeDelta = N / scaleFactor. Do NOT include referencePixelsPerUnit here.
+            float u = Mathf.Round(px) / sf;
 
             // Top
             var trt = _top.rectTransform;


### PR DESCRIPTION
## Summary
- ensure UIFrame border thickness ignores reference pixels per unit

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b68e97491c832491a5a4de9ba88711