### PR TITLE
Fix Destroy call in UICreator CloseMenus

### DIFF
--- a/Assets/Scripts/UI/Screens/UICreatorScreen.cs
+++ b/Assets/Scripts/UI/Screens/UICreatorScreen.cs
@@ -150,7 +150,7 @@ namespace FantasyColony.UI.Screens
         {
             if (_openMenu != null)
             {
-                Destroy(_openMenu.gameObject);
+                UnityObject.Destroy(_openMenu.gameObject);
                 _openMenu = null;
             }
             if (_menuOverlay != null) _menuOverlay.gameObject.SetActive(false);


### PR DESCRIPTION
## Summary
- Use `UnityObject.Destroy` when closing menus to avoid MonoBehaviour dependency

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d6d56b048324afbf84ce784f9bb4