### PR TITLE
Ensure buttons size correctly outside layout and anchor menus to toolbar buttons

### DIFF
--- a/Assets/Scripts/UI/Screens/UICreatorScreen.cs
+++ b/Assets/Scripts/UI/Screens/UICreatorScreen.cs
@@ -19,6 +19,7 @@ namespace FantasyColony.UI.Screens
         // Program-window layout: Top toolbar (percent height) + large blank stage
         private RectTransform _toolbar;
         private RectTransform _stage;
+        private RectTransform _btnFile, _btnEdit, _btnView, _btnTools, _btnClose;
         private const float TOOLBAR_FRAC = 0.05f; // 5% of screen height
 
         public void Enter(Transform parent)
@@ -77,12 +78,12 @@ namespace FantasyColony.UI.Screens
 
             // --- Toolbar content: equal-width buttons across full width ---
             // Create equal-width buttons directly under the toolbar (no nested Row)
-            var fileBtn = CreateFlexMenuButton(_toolbar, "File",  OnFileMenu);
-            var editBtn = CreateFlexMenuButton(_toolbar, "Edit",  OnEditMenu);
-            var viewBtn = CreateFlexMenuButton(_toolbar, "View",  OnViewMenu);
-            var toolBtn = CreateFlexMenuButton(_toolbar, "Tools", OnToolsMenu);
+            _btnFile  = CreateFlexMenuButton(_toolbar, "File",  OnFileMenu);
+            _btnEdit  = CreateFlexMenuButton(_toolbar, "Edit",  OnEditMenu);
+            _btnView  = CreateFlexMenuButton(_toolbar, "View",  OnViewMenu);
+            _btnTools = CreateFlexMenuButton(_toolbar, "Tools", OnToolsMenu);
             // Remove Help per request
-            var closeBtn = CreateFlexMenuButton(_toolbar, "Close", () => UIRouter.Current?.Pop());
+            _btnClose = CreateFlexMenuButton(_toolbar, "Close", () => UIRouter.Current?.Pop());
 
             IsOpen = true;
         }
@@ -198,21 +199,21 @@ namespace FantasyColony.UI.Screens
         // --- Menu actions (stubs) ---
         private void OnFileMenu()
         {
-            ShowMenu(_toolbar, ("New", ()=>Debug.Log("[UICreator] File/New")),
-                             ("Save", ()=>Debug.Log("[UICreator] File/Save (stub)")),
-                             ("Load", ()=>Debug.Log("[UICreator] File/Load (stub)")));
+            ShowMenu(_btnFile, ("New", ()=>Debug.Log("[UICreator] File/New")),
+                              ("Save", ()=>Debug.Log("[UICreator] File/Save (stub)")),
+                              ("Load", ()=>Debug.Log("[UICreator] File/Load (stub)")));
         }
 
         private void OnEditMenu() { Debug.Log("[UICreator] Edit (stub)"); }
 
         private void OnViewMenu()
         {
-            ShowMenu(_toolbar, ("Fullscreen Work Area", ()=> ToggleFullscreenWorkArea()));
+            ShowMenu(_btnView, ("Fullscreen Work Area", ()=> ToggleFullscreenWorkArea()));
         }
 
         private void OnToolsMenu()
         {
-            ShowMenu(_toolbar,
+            ShowMenu(_btnTools,
                 ("Add Primary Button", ()=> SpawnButton("UI_PrimaryButton", UIFactory.CreateButtonPrimary)),
                 ("Add Secondary Button", ()=> SpawnButton("UI_SecondaryButton", UIFactory.CreateButtonSecondary)),
                 ("Add Danger Button", ()=> SpawnButton("UI_DangerButton", UIFactory.CreateButtonDanger)),
@@ -234,7 +235,8 @@ namespace FantasyColony.UI.Screens
             var btn = ctor(_stage, name.Replace("UI_", string.Empty), ()=>{});
             btn.gameObject.name = name;
             var rt = btn.GetComponent<RectTransform>();
-            rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.5f);
+            // Apply factory defaults so buttons spawned outside a LayoutGroup are visible and usable
+            UIFactory.ApplyDefaultButtonSizing(rt);
             rt.anchoredPosition = Vector2.zero;
             Debug.Log($"[UICreator] Spawn {name}");
         }

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -17,6 +17,55 @@ namespace FantasyColony.UI.Widgets
         private static Sprite _darkBorderSymmetric;
         private static Material _grayscaleTintMat;
 
+        // ---- Button sizing helpers (safe defaults when outside a LayoutGroup) ----
+        /// <summary>
+        /// Returns true if any parent has a LayoutGroup (Horizontal/Vertical/Grid).
+        /// </summary>
+        public static bool ParentHasLayoutGroup(Transform t)
+        {
+            if (t == null) return false;
+            Transform p = t.parent;
+            while (p != null)
+            {
+                if (p.GetComponent<HorizontalLayoutGroup>() != null ||
+                    p.GetComponent<VerticalLayoutGroup>()   != null ||
+                    p.GetComponent<GridLayoutGroup>()       != null)
+                    return true;
+                p = p.parent;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Apply sane default sizing to a Button's RectTransform when not controlled by a LayoutGroup.
+        /// In a free (no-layout) container, set explicit size; in a layout, only ensure a stable height.
+        /// Idempotent.
+        /// </summary>
+        public static void ApplyDefaultButtonSizing(RectTransform rt, Vector2? freeSize = null)
+        {
+            if (rt == null) return;
+            var size = freeSize ?? new Vector2(240f, 64f);
+            var le = rt.GetComponent<LayoutElement>();
+            if (le == null) le = rt.gameObject.AddComponent<LayoutElement>();
+
+            if (!ParentHasLayoutGroup(rt))
+            {
+                // Free stage: give it an explicit, visible size centered on the stage.
+                rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.5f);
+                rt.sizeDelta = size.Value;
+                rt.anchoredPosition = Vector2.zero;
+                // Allow later manual resizing by authoring tools
+                le.minWidth = 0f; le.preferredWidth = 0f; le.flexibleWidth = 0f;
+                le.minHeight = 0f; le.preferredHeight = size.Value.y; le.flexibleHeight = 0f;
+            }
+            else
+            {
+                // In a LayoutGroup: don't force width; provide a sensible preferred height for the row.
+                le.minWidth = 0f; le.preferredWidth = 0f; le.flexibleWidth = 0f;
+                le.minHeight = 0f; le.preferredHeight = 48f; le.flexibleHeight = 0f;
+            }
+        }
+
         // Ensure the 9-slice border has equal left/right and top/bottom edge sizes.
         // This avoids visual asymmetry when Unity stretches the sliced edges.
         private static Sprite GetSymmetricDarkBorder()


### PR DESCRIPTION
## Summary
- add `ParentHasLayoutGroup` and `ApplyDefaultButtonSizing` helpers to UIFactory
- store toolbar button rects and anchor dropdown menus to the correct button
- use default sizing when spawning buttons so they appear usable outside layouts

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8989feae48324bb85f64405f6d039