### PR TITLE
Expand UIFactory layout utilities and docs

### DIFF
--- a/Assets/Scripts/UI/Screens/UICreatorScreen.cs
+++ b/Assets/Scripts/UI/Screens/UICreatorScreen.cs
@@ -73,8 +73,8 @@ namespace FantasyColony.UI.Screens
             _stage.SetParent(absRT, false);
 
             // Anchors: toolbar = top 5% height, stage = remaining 95%
-            SetAnchorsPercent(_toolbar, xMin:0f, xMax:1f, yMin:1f-TOOLBAR_FRAC, yMax:1f);
-            SetAnchorsPercent(_stage,   xMin:0f, xMax:1f, yMin:0f,              yMax:1f-TOOLBAR_FRAC);
+            UIFactory.SetAnchorsPercent(_toolbar, xMin:0f, xMax:1f, yMin:1f - TOOLBAR_FRAC, yMax:1f);
+            UIFactory.SetAnchorsPercent(_stage, xMin:0f, xMax:1f, yMin:0f, yMax:1f - TOOLBAR_FRAC);
 
             // --- Toolbar content: equal-width buttons across full width ---
             // Create equal-width buttons directly under the toolbar (no nested Row)
@@ -118,14 +118,6 @@ namespace FantasyColony.UI.Screens
                 txt.resizeTextMaxSize = 28;
             }
             return btn.GetComponent<RectTransform>();
-        }
-
-        private static void SetAnchorsPercent(RectTransform rt, float xMin, float xMax, float yMin, float yMax)
-        {
-            rt.anchorMin = new Vector2(xMin, yMin);
-            rt.anchorMax = new Vector2(xMax, yMax);
-            rt.offsetMin = Vector2.zero;
-            rt.offsetMax = Vector2.zero;
         }
 
         // --- Simple dropdown framework (stub for Step 1) ---
@@ -234,9 +226,7 @@ namespace FantasyColony.UI.Screens
 
             var panel = UIFactory.CreatePanelSurface(_stage, "UI_Panel");
             var prt = panel;
-            prt.anchorMin = prt.anchorMax = new Vector2(0.5f, 0.5f);
-            prt.sizeDelta = new Vector2(480f, 320f);
-            prt.anchoredPosition = Vector2.zero;
+            UIFactory.ApplyDefaultPanelSizing(prt);
             Debug.Log("[UICreator] Spawn UI_Panel");
         }
     }

--- a/Docs/UIFactory_Reference.md
+++ b/Docs/UIFactory_Reference.md
@@ -1,0 +1,31 @@
+## UIFactory Reference (FantasyColony)
+
+**Purpose:** Single source of reusable UI helpers. All screens (including UI Creator) should use these instead of ad-hoc code.
+
+### Layout utilities
+- `SetAnchorsPercent(RectTransform rt, float xMin, float xMax, float yMin, float yMax)` – Set normalized anchors and zero offsets.
+- `ParentHasLayoutGroup(Transform t)` – True if any parent has a `Horizontal/Vertical/GridLayoutGroup`.
+- `SplitPercentH(Transform parent, params float[] percents)` – Create children filling a row by percentages (no LayoutGroups). Returns `RectTransform[]`.
+- `SplitPercentV(Transform parent, params float[] percents)` – Vertical counterpart.
+- `EnsureLayoutElement(GameObject go)` – Return existing or add a `LayoutElement`.
+
+### Sizing policies
+- `ApplyDefaultButtonSizing(RectTransform rt, Vector2? freeSize=null)` – If outside a LayoutGroup, set explicit size (default 240×64) and center; inside a layout, suggest a stable preferred height.
+- `ApplyDefaultPanelSizing(RectTransform rt, Vector2? freeSize=null)` – Same policy for panels (default 480×320).
+
+### Menus & overlays
+- `struct MenuItem { string Label; Action OnClick; bool Separator; }`
+- `CreateDropdownMenu(RectTransform overlay, RectTransform anchor, IList<MenuItem> items, float rowHeight=32, float minWidth=160, bool matchAnchorWidth=true)`
+  - Overlay: full-screen RectTransform, no LayoutGroup, transparent Image with `raycastTarget=true`.
+  - Positions the dropdown under the anchor; sizes with `VerticalLayoutGroup + ContentSizeFitter (Preferred Y)`.
+
+### Feedback widgets (stubs)
+- `ShowToast(...)` *(planned)* – small non-blocking message.
+
+### Raycast & borders
+- `SetRaycast(GameObject go, bool on)` *(planned)* – toggle raycast on common graphics.
+- `JoinBorders(params UIFrame[])` *(planned)* – hide internal seams where panels touch.
+
+**Rules:**
+- Structural containers = **Flexible**. Use anchors or LayoutGroup + flexible; do **not** add `ContentSizeFitter` to objects that are also in a LayoutGroup.
+- Small widgets (dropdowns, toasts) may use `ContentSizeFitter` on the widget **root** when it isn’t inside a LayoutGroup.


### PR DESCRIPTION
## Summary
- add SetAnchorsPercent, EnsureLayoutElement, SplitPercentH/V, and ApplyDefaultPanelSizing to UIFactory
- document UIFactory helpers and policies
- use new UIFactory helpers in UICreatorScreen

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a236bcb08324aaf537a8eaaf0326