### PR TITLE
Fix Vector2 nullable usage in panel sizing

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -132,11 +132,11 @@ namespace FantasyColony.UI.Widgets
             if (!ParentHasLayoutGroup(rt))
             {
                 rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.5f);
-                rt.sizeDelta = size.Value;
+                rt.sizeDelta = size;
                 rt.anchoredPosition = Vector2.zero;
             }
             le.minWidth = 0f; le.preferredWidth = 0f; le.flexibleWidth = 0f;
-            le.minHeight = 0f; le.preferredHeight = size.Value.y; le.flexibleHeight = 0f;
+            le.minHeight = 0f; le.preferredHeight = size.y; le.flexibleHeight = 0f;
         }
 
         // ---- Dropdown Menu ----


### PR DESCRIPTION
## Summary
- fix nullable Vector2 usage in ApplyDefaultPanelSizing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a88790248324b28687dfe146a2ae