### PR TITLE
Handle missing InputSystem module in legacy UI root

### DIFF
--- a/Assets/Scripts/UI/Root/UIRoot.cs
+++ b/Assets/Scripts/UI/Root/UIRoot.cs
@@ -64,8 +64,16 @@ namespace FantasyColony.UI.Root
                 esys.gameObject.AddComponent<InputSystemUIInputModule>();
 #else
             // Legacy Input (Standalone)
-            var newMod = esys.GetComponent<UnityEngine.InputSystem.UI.InputSystemUIInputModule>();
-            if (newMod != null) Destroy(newMod);
+            // Remove any leftover InputSystemUIInputModule via reflection so this compiles
+            // even if the new Input System package is not installed.
+            var newInputModuleType = System.Type.GetType(
+                "UnityEngine.InputSystem.UI.InputSystemUIInputModule, Unity.InputSystem");
+            if (newInputModuleType != null)
+            {
+                var newMod = esys.GetComponent(newInputModuleType);
+                if (newMod != null)
+                    Destroy(newMod);
+            }
             if (esys.GetComponent<StandaloneInputModule>() == null)
                 esys.gameObject.AddComponent<StandaloneInputModule>();
 #endif


### PR DESCRIPTION
## Summary
- Remove leftover InputSystemUIInputModule via reflection in legacy UI setup
- Avoid direct references to Unity.InputSystem when the package is absent

## Testing
- ⚠️ `dotnet build` (command not found)
- ⚠️ `apt-get update` (403 Forbidden)
- ⚠️ `apt-get install -y dotnet-sdk-7.0` (package not found)


------
https://chatgpt.com/codex/tasks/task_e_68b8aa71aac48324b24cf4d7491bdf2a