### PR TITLE
Add Clear method to GrayscaleSpriteCache and invoke on shutdown

### DIFF
--- a/Assets/Scripts/Core/AppFlow.cs
+++ b/Assets/Scripts/Core/AppFlow.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using UnityEngine;
 using FantasyColony.UI.Router;
 using FantasyColony.UI.Screens;
+using FantasyColony.UI.Util;
 
 namespace FantasyColony.Core {
     /// <summary>
@@ -41,6 +42,7 @@ namespace FantasyColony.Core {
             // Give UI one frame to present cover
             yield return null;
 
+            GrayscaleSpriteCache.Clear();
             // Free anything not referenced anymore
             yield return Resources.UnloadUnusedAssets();
             System.GC.Collect();

--- a/Assets/Scripts/Core/AppHost.cs
+++ b/Assets/Scripts/Core/AppHost.cs
@@ -3,6 +3,7 @@ using FantasyColony.UI.Root;
 using FantasyColony.UI.Router;
 using FantasyColony.Core.Services;
 using FantasyColony.UI.Screens;
+using FantasyColony.UI.Util;
 
 // Disambiguate our service interfaces from Unity's similarly named types
 using FCLogger = FantasyColony.Core.Services.ILogger;
@@ -75,7 +76,11 @@ namespace FantasyColony.Core
 
         private void OnDestroy()
         {
-            if (Instance == this) Instance = null;
+            if (Instance == this)
+            {
+                Instance = null;
+                GrayscaleSpriteCache.Clear();
+            }
         }
     }
 }

--- a/Assets/Scripts/UI/Util/GrayscaleSpriteCache.cs
+++ b/Assets/Scripts/UI/Util/GrayscaleSpriteCache.cs
@@ -50,6 +50,19 @@ namespace FantasyColony.UI.Util
             return sp;
         }
 
+        public static void Clear()
+        {
+            foreach (var sp in _cache.Values)
+            {
+                if (sp == null) continue;
+                var tex = sp.texture;
+                if (tex != null)
+                    Object.Destroy(tex);
+                Object.Destroy(sp);
+            }
+            _cache.Clear();
+        }
+
         private static string MakeKey(Sprite s)
         {
             var r = s.rect;


### PR DESCRIPTION
## Summary
- add `GrayscaleSpriteCache.Clear()` to dispose grayscale textures and empty cache
- clear grayscale cache when restarting or when `AppHost` is destroyed

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Unable to locate package dotnet-sdk-6.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aa76ac74832489f910fc3ccf1203