### PR TITLE
Track grayscale sprite usage for cleanup

### DIFF
--- a/Assets/Scripts/UI/Util/GrayscaleSpriteCache.cs
+++ b/Assets/Scripts/UI/Util/GrayscaleSpriteCache.cs
@@ -6,13 +6,22 @@ namespace FantasyColony.UI.Util
     public static class GrayscaleSpriteCache
     {
         // Cache by source texture instanceID + rect
-        private static readonly Dictionary<string, Sprite> _cache = new();
+        private class Entry
+        {
+            public Sprite Sprite;
+            public int RefCount;
+        }
+        private static readonly Dictionary<string, Entry> _cache = new();
 
         public static Sprite Get(Sprite source)
         {
             if (source == null) return null;
             var key = MakeKey(source);
-            if (_cache.TryGetValue(key, out var s)) return s;
+            if (_cache.TryGetValue(key, out var e))
+            {
+                e.RefCount++;
+                return e.Sprite;
+            }
 
             var rect = source.rect;
             var tex = source.texture;
@@ -46,14 +55,33 @@ namespace FantasyColony.UI.Util
 
             // Create a sprite with same PPU and pivot
             var sp = Sprite.Create(tmp, new Rect(0, 0, w, h), new Vector2(0.5f, 0.5f), source.pixelsPerUnit, 0, SpriteMeshType.FullRect);
-            _cache[key] = sp;
+            _cache[key] = new Entry { Sprite = sp, RefCount = 1 };
             return sp;
+        }
+
+        public static void Release(Sprite source)
+        {
+            if (source == null) return;
+            var key = MakeKey(source);
+            if (!_cache.TryGetValue(key, out var e)) return;
+            e.RefCount--;
+            if (e.RefCount > 0) return;
+
+            if (e.Sprite != null)
+            {
+                var tex = e.Sprite.texture;
+                if (tex != null)
+                    Object.Destroy(tex);
+                Object.Destroy(e.Sprite);
+            }
+            _cache.Remove(key);
         }
 
         public static void Clear()
         {
-            foreach (var sp in _cache.Values)
+            foreach (var e in _cache.Values)
             {
+                var sp = e.Sprite;
                 if (sp == null) continue;
                 var tex = sp.texture;
                 if (tex != null)


### PR DESCRIPTION
## Summary
- reference count grayscale sprites in cache and expose release API
- track grayscale sprite ownership in UIFactory so textures are released when unused

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8abf0aa548324a5588fa697b7c404