### PR TITLE
UIFactory: add UnityObject alias to avoid System.Object ambiguity

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using System;
 using System.Collections.Generic;
+using UnityObject = UnityEngine.Object;
 using System.Linq;
 using FantasyColony; // for GetHierarchyPath()
 using FantasyColony.UI.Style;


### PR DESCRIPTION
## Summary
- add UnityObject alias to avoid System.Object ambiguity in UIFactory

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b0de41708324bf6911f89778e6aa