### PR TITLE
Clarify Unity Object reference in UIFactory

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -316,7 +316,7 @@ namespace FantasyColony.UI.Widgets
                 }
                 else if (tracker != null && tracker.Source == null)
                 {
-                    Object.Destroy(tracker);
+                    UnityObject.Destroy(tracker);
                 }
                 Debug.LogWarning($"UIFactory: Using CPU grayscale fallback on {img.transform.GetHierarchyPath()}.");
                 return;
@@ -328,7 +328,7 @@ namespace FantasyColony.UI.Widgets
                 GrayscaleSpriteCache.Release(tracker.Source);
                 tracker.Source = null;
                 tracker.Gray = null;
-                Object.Destroy(tracker);
+                UnityObject.Destroy(tracker);
                 tracker = null;
             }
 


### PR DESCRIPTION
## Summary
- fix ambiguous Object reference in UIFactory by using UnityObject alias

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b32bd4408324b5b73efba6d7ab6a