### PR TITLE
UICreator: add toolbar hotkeys

### DIFF
--- a/Assets/Scripts/UI/Root/UIRoot.cs
+++ b/Assets/Scripts/UI/Root/UIRoot.cs
@@ -12,6 +12,8 @@ namespace FantasyColony.UI.Root
     {
         public RectTransform ScreenParent { get; private set; }
 
+        public static event System.Action OnUpdate;
+
         public static UIRoot Create(Transform parent)
         {
             var go = new GameObject("UIRoot");
@@ -86,6 +88,11 @@ namespace FantasyColony.UI.Root
             ScreenParent.anchorMax = Vector2.one;
             ScreenParent.offsetMin = Vector2.zero;
             ScreenParent.offsetMax = Vector2.zero;
+        }
+
+        private void Update()
+        {
+            OnUpdate?.Invoke();
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow Creator toolbar to be toggled with F11 and restored with Esc
- reset toolbar and register/unregister hotkeys when entering/exiting
- expose `UIRoot.OnUpdate` event for lightweight per-frame hotkey handling

## Testing
- ⚠️ `dotnet test` *(command not found)*
- ⚠️ `apt-get update` *(403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b8171bc083248819a92698b7ab3d