### PR TITLE
Fix duplicate local variable in UIFactory

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -220,10 +220,10 @@ namespace FantasyColony.UI.Widgets
 
         // Determine canvas camera (ScreenSpaceOverlay => null)
         Camera cam = null;
-        var canvas = overlay.GetComponentInParent<Canvas>();
-        if (canvas != null && canvas.renderMode != RenderMode.ScreenSpaceOverlay)
+        var parentCanvas = overlay.GetComponentInParent<Canvas>();
+        if (parentCanvas != null && parentCanvas.renderMode != RenderMode.ScreenSpaceOverlay)
         {
-            cam = canvas.worldCamera != null ? canvas.worldCamera : Camera.main;
+            cam = parentCanvas.worldCamera != null ? parentCanvas.worldCamera : Camera.main;
         }
 
         // Convert to overlay local space


### PR DESCRIPTION
## Summary
- Avoid CS0128 by renaming second `canvas` variable to `parentCanvas` in `UIFactory`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f1449c40832496bd651059a795aa