### PR TITLE
Fix outdated UIFrame API usage in UIFactory

### DIFF
--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -1022,7 +1022,7 @@ namespace FantasyColony.UI.Widgets
             // Ensure our default wood frame skin
             var frame = go.GetComponent<UIFrame>();
             if (frame == null) frame = go.AddComponent<UIFrame>();
-            frame.SetBorderEnabled(true, true, true, true);
+            frame.SetEdges(true, true, true, true);
 
             // Find/create caption label
             Text caption = go.GetComponentInChildren<Text>();


### PR DESCRIPTION
## Summary
- Use UIFrame.SetEdges instead of non-existent SetBorderEnabled when attaching dropdown menus

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fc8761ac83248f43332bed58490b