### PR TITLE
Docs: Switch Mod Packaging doc to XML; remove YAML mentions

### DIFF
--- a/Docs/Design/Mod-Packaging-and-Load-Order-v0.1.md
+++ b/Docs/Design/Mod-Packaging-and-Load-Order-v0.1.md
@@ -1,18 +1,26 @@
 # Mod Packaging & Load Order (v0.1)
-> **Update:** Localization & Assets layout.
+> **Update:** Localization & Assets layout. (XML-first authoring)
 
 ## Layout
-- **Defs:** `mods/<modid>/defs/*.yaml`
+- **Defs:** `mods/<modid>/defs/**/*.xml`
 - **Localization:** `mods/<modid>/localization/<locale>.json` (ICU strings)
 - **Icons:** `mods/<modid>/icons/*`
 - **Sprites:** `mods/<modid>/sprites/*` (raw sheets)
 - **Atlas:** `mods/<modid>/atlas/*` (packed PNGs + AtlasDef)
 - **Fonts:** `mods/<modid>/fonts/*`
-- **About:** `mods/<modid>/about.yaml`
+- **About:** `mods/<modid>/about.xml`
 
 ## Import/Export
-- Localization: CSV/XLIFF round-trip; keep key stability; renames update refs.
-- Assets: drag-drop import; auto-thumbs to `.thumbs/`.
+- **Localization:** CSV/XLIFF round‑trip; keep key stability; renames update refs.
+- **Assets:** Drag‑drop import; auto‑thumbs to `.thumbs/`.
+- **Defs:** Editor and CLI tools write XML with normalized attribute ordering to minimize diff churn.
 
 ## Load Order
-- Same as before; packs can override keys/assets by path, but prefer **PatchDef** for Def changes. Editor warns on path overrides.
+- Same as before; packs can override localization keys/assets by path, but prefer **PatchDef** for Def changes.
+- The editor warns on path overrides and visualizes effective load order.
+- Mods declare dependencies (`requires`), versions (`version`), and optional patch operations in their `about.xml`.
+
+## Notes
+- Def filenames mirror their canonical IDs (`<id>.xml`), organized by schema‑specific folders.
+- Auto‑generated XML artifacts live in the repo (`XML_INDEX.md`, `XML_SNAPSHOT.txt`, `Docs/Templates/Defs/*.xml`).
+


### PR DESCRIPTION
## Summary
- Update Mod Packaging & Load Order doc to favor XML authoring and adjust layout

## Testing
- `pre-commit run --files Docs/Design/Mod-Packaging-and-Load-Order-v0.1.md` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d01a2688324a935dd86201dddf0