### PR TITLE
Enable instruction notes in UI Creator

### DIFF
--- a/Assets/Scripts/UI/Creator/Editing/InstructionDialog.cs
+++ b/Assets/Scripts/UI/Creator/Editing/InstructionDialog.cs
@@ -1,0 +1,131 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace FantasyColony.UI.Creator.Editing
+{
+    /// <summary>
+    /// Runtime-built modal dialog to attach instructions to the selected item.
+    /// </summary>
+    public static class InstructionDialog
+    {
+        public static void Show(RectTransform parent, RectTransform target)
+        {
+            if (parent == null || target == null) { Debug.LogWarning("[UICreator] InstructionDialog missing parent/target"); return; }
+
+            // Blocker overlay
+            var overlayGO = new GameObject("InstructionDialog", typeof(RectTransform), typeof(Image));
+            var overlay = overlayGO.GetComponent<RectTransform>();
+            overlay.SetParent(parent, false);
+            overlay.anchorMin = Vector2.zero; overlay.anchorMax = Vector2.one; overlay.pivot = new Vector2(0.5f, 0.5f);
+            overlay.offsetMin = overlay.offsetMax = Vector2.zero;
+            var blocker = overlayGO.GetComponent<Image>();
+            blocker.color = new Color(0, 0, 0, 0.5f);
+            blocker.raycastTarget = true;
+
+            // Panel
+            var panelGO = UIFactory.CreatePanelSurface(overlay, "Instructions", sizing: PanelSizing.AutoHeight);
+            var panel = panelGO.GetComponent<RectTransform>();
+            panel.anchorMin = panel.anchorMax = new Vector2(0.5f, 0.5f);
+            panel.pivot = new Vector2(0.5f, 0.5f);
+            panel.sizeDelta = new Vector2(520, 360);
+
+            // Title
+            var titleGO = new GameObject("Title", typeof(RectTransform), typeof(Text));
+            var titleRT = titleGO.GetComponent<RectTransform>();
+            titleRT.SetParent(panel, false);
+            titleRT.anchorMin = new Vector2(0, 1); titleRT.anchorMax = new Vector2(1, 1); titleRT.pivot = new Vector2(0.5f, 1f);
+            titleRT.offsetMin = new Vector2(16, -40); titleRT.offsetMax = new Vector2(-16, -8);
+            var title = titleGO.GetComponent<Text>();
+            title.alignment = TextAnchor.MiddleLeft;
+            title.text = "Instructions";
+
+            // Input background
+            var inputBG = new GameObject("InputBG", typeof(RectTransform), typeof(Image));
+            var inputBGRT = inputBG.GetComponent<RectTransform>();
+            inputBGRT.SetParent(panel, false);
+            inputBGRT.anchorMin = new Vector2(0, 0); inputBGRT.anchorMax = new Vector2(1, 1); inputBGRT.pivot = new Vector2(0.5f, 0.5f);
+            inputBGRT.offsetMin = new Vector2(16, 64); inputBGRT.offsetMax = new Vector2(-16, 64);
+
+            // Input field
+            var inputGO = new GameObject("Input", typeof(RectTransform), typeof(Image), typeof(InputField));
+            var inputRT = inputGO.GetComponent<RectTransform>();
+            inputRT.SetParent(panel, false);
+            inputRT.anchorMin = new Vector2(0, 0); inputRT.anchorMax = new Vector2(1, 1); inputRT.pivot = new Vector2(0.5f, 0.5f);
+            inputRT.offsetMin = new Vector2(16, 64); inputRT.offsetMax = new Vector2(-16, 96);
+            var inputImg = inputGO.GetComponent<Image>(); inputImg.raycastTarget = true;
+            var field = inputGO.GetComponent<InputField>();
+            field.lineType = InputField.LineType.MultiLineNewline;
+
+            // Text components for InputField
+            var textGO = new GameObject("Text", typeof(RectTransform), typeof(Text));
+            var textRT = textGO.GetComponent<RectTransform>();
+            textRT.SetParent(inputGO.transform, false);
+            textRT.anchorMin = new Vector2(0, 0); textRT.anchorMax = new Vector2(1, 1); textRT.pivot = new Vector2(0.5f, 0.5f);
+            textRT.offsetMin = new Vector2(8, 8); textRT.offsetMax = new Vector2(-8, -8);
+            var text = textGO.GetComponent<Text>();
+            text.alignment = TextAnchor.UpperLeft;
+            field.textComponent = text;
+
+            var phGO = new GameObject("Placeholder", typeof(RectTransform), typeof(Text));
+            var phRT = phGO.GetComponent<RectTransform>();
+            phRT.SetParent(inputGO.transform, false);
+            phRT.anchorMin = new Vector2(0, 0); phRT.anchorMax = new Vector2(1, 1); phRT.pivot = new Vector2(0.5f, 0.5f);
+            phRT.offsetMin = new Vector2(8, 8); phRT.offsetMax = new Vector2(-8, -8);
+            var ph = phGO.GetComponent<Text>();
+            ph.alignment = TextAnchor.UpperLeft; ph.text = "Type instructions here...";
+            ph.color = new Color(1, 1, 1, 0.5f);
+            field.placeholder = ph;
+
+            // Load existing note
+            var note = target.GetComponent<UIInstructionNote>();
+            if (note != null) field.text = note.Note;
+
+            // Buttons container
+            var btnBar = new GameObject("Buttons", typeof(RectTransform));
+            var btnBarRT = btnBar.GetComponent<RectTransform>();
+            btnBarRT.SetParent(panel, false);
+            btnBarRT.anchorMin = new Vector2(0, 0); btnBarRT.anchorMax = new Vector2(1, 0); btnBarRT.pivot = new Vector2(0.5f, 0f);
+            btnBarRT.sizeDelta = new Vector2(0, 48); btnBarRT.anchoredPosition = new Vector2(0, 16);
+
+            // Save button
+            var save = CreateButton(btnBarRT, "Save", new Vector2(1f, 0.5f), new Vector2(-16, 0));
+            save.onClick.AddListener(() =>
+            {
+                var n = target.GetComponent<UIInstructionNote>();
+                if (n == null) n = target.gameObject.AddComponent<UIInstructionNote>();
+                n.Note = field.text ?? string.Empty;
+                Object.Destroy(overlayGO);
+                Debug.Log($"[UICreator] Instructions saved for {target.name}");
+            });
+
+            // Cancel button
+            var cancel = CreateButton(btnBarRT, "Cancel", new Vector2(0f, 0.5f), new Vector2(16, 0));
+            cancel.onClick.AddListener(() =>
+            {
+                Object.Destroy(overlayGO);
+                Debug.Log("[UICreator] Instructions canceled");
+            });
+        }
+
+        private static Button CreateButton(RectTransform parent, string label, Vector2 anchor, Vector2 margin)
+        {
+            var go = new GameObject(label + "Button", typeof(RectTransform), typeof(Image), typeof(Button));
+            var rt = go.GetComponent<RectTransform>();
+            rt.SetParent(parent, false);
+            rt.anchorMin = rt.anchorMax = anchor;
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.sizeDelta = new Vector2(120, 36);
+            rt.anchoredPosition = new Vector2(Mathf.Lerp(-parent.rect.width * 0.5f + 80, parent.rect.width * 0.5f - 80, anchor.x), 0) + margin;
+            var btn = go.GetComponent<Button>();
+
+            var txtGO = new GameObject("Text", typeof(RectTransform), typeof(Text));
+            var txtRT = txtGO.GetComponent<RectTransform>();
+            txtRT.SetParent(rt, false);
+            txtRT.anchorMin = new Vector2(0, 0); txtRT.anchorMax = new Vector2(1, 1); txtRT.pivot = new Vector2(0.5f, 0.5f);
+            var txt = txtGO.GetComponent<Text>();
+            txt.alignment = TextAnchor.MiddleCenter; txt.text = label;
+            return btn;
+        }
+    }
+}
+

--- a/Assets/Scripts/UI/Creator/Editing/UIInstructionNote.cs
+++ b/Assets/Scripts/UI/Creator/Editing/UIInstructionNote.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace FantasyColony.UI.Creator.Editing
+{
+    /// <summary>
+    /// Simple metadata component to store per-item instructions/notes.
+    /// </summary>
+    public sealed class UIInstructionNote : MonoBehaviour
+    {
+        [TextArea(3, 10)] public string Note = string.Empty;
+    }
+}
+

--- a/Assets/Scripts/UI/Creator/Editing/UISelectionBox.cs
+++ b/Assets/Scripts/UI/Creator/Editing/UISelectionBox.cs
@@ -13,6 +13,8 @@ namespace FantasyColony.UI.Creator.Editing
     {
         private static UISelectionBox _current;
 
+        public static RectTransform CurrentTarget => _current != null ? _current._target : null;
+
         [SerializeField] private RectTransform _target; // self by default
         [SerializeField] private RectTransform _stage;
         [SerializeField] private RectTransform _overlay; // visual box parent

--- a/Assets/Scripts/UI/Screens/UICreatorScreen.cs
+++ b/Assets/Scripts/UI/Screens/UICreatorScreen.cs
@@ -267,27 +267,28 @@ namespace FantasyColony.UI.Screens
         {
             if (background)
             {
-                var go = new GameObject("UI_BackgroundPanel", typeof(RectTransform), typeof(Image));
-                var rt = go.GetComponent<RectTransform>();
-                var img = go.GetComponent<Image>();
-                img.color = new Color(0f,0f,0f,0f);
-                img.raycastTarget = false;
-                rt.SetParent(_stage, false);
-                rt.anchorMin = new Vector2(0.1f, 0.1f);
-                rt.anchorMax = new Vector2(0.9f, 0.9f);
-                rt.offsetMin = rt.offsetMax = Vector2.zero;
-                NormalizePlaceable(rt);
-                AttachEditing(rt);
-                Debug.Log("[UICreator] Spawn UI_BackgroundPanel");
+                var panelGO = UIFactory.CreatePanelSurface(_stage, "UI_BackgroundPanel", sizing: PanelSizing.AutoBoth);
+                var rt = panelGO != null ? panelGO.GetComponent<RectTransform>() : null;
+                if (rt != null)
+                {
+                    UIFactory.EnsureRaycastTarget(rt);
+                    NormalizePlaceable(rt);
+                    AttachEditing(rt);
+                    Debug.Log("[UICreator] Spawn UI_BackgroundPanel");
+                }
                 return;
             }
 
-            var panel = UIFactory.CreatePanelSurface(_stage, "UI_Panel");
-            var prt = panel;
-            UIFactory.ApplyDefaultPanelSizing(prt);
-            NormalizePlaceable(prt);
-            AttachEditing(prt);
-            Debug.Log("[UICreator] Spawn UI_Panel");
+            var panelGO2 = UIFactory.CreatePanelSurface(_stage, "UI_Panel", sizing: PanelSizing.AutoBoth);
+            var prt = panelGO2 != null ? panelGO2.GetComponent<RectTransform>() : null;
+            if (prt != null)
+            {
+                UIFactory.ApplyDefaultPanelSizing(prt);
+                UIFactory.EnsureRaycastTarget(prt);
+                NormalizePlaceable(prt);
+                AttachEditing(prt);
+                Debug.Log("[UICreator] Spawn UI_Panel");
+            }
         }
 
         private void NormalizePlaceable(RectTransform t)
@@ -318,10 +319,12 @@ namespace FantasyColony.UI.Screens
             bool g = Keyboard.current != null && Keyboard.current.gKey.wasPressedThisFrame;
             bool ctrl = Keyboard.current != null && (Keyboard.current.leftCtrlKey.isPressed || Keyboard.current.rightCtrlKey.isPressed);
             bool f4 = Keyboard.current != null && Keyboard.current.f4Key.wasPressedThisFrame;
+            bool iKey = Keyboard.current != null && Keyboard.current.iKey.wasPressedThisFrame;
 #else
             bool g = Input.GetKeyDown(KeyCode.G);
             bool ctrl = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
             bool f4 = Input.GetKeyDown(KeyCode.F4);
+            bool iKey = Input.GetKeyDown(KeyCode.I);
 #endif
             if (g)
             {
@@ -340,6 +343,19 @@ namespace FantasyColony.UI.Screens
             {
                 GridPrefs.SnapEnabled = !GridPrefs.SnapEnabled;
                 Debug.Log($"[UICreator] Snap {(GridPrefs.SnapEnabled ? "on" : "off")}");
+            }
+
+            if (iKey)
+            {
+                var sel = UISelectionBox.CurrentTarget;
+                if (sel != null)
+                {
+                    InstructionDialog.Show(_stage, sel);
+                }
+                else
+                {
+                    Debug.Log("[UICreator] No selection for Instructions dialog");
+                }
             }
         }
     }

--- a/Assets/Scripts/UI/Widgets/UIFactory.cs
+++ b/Assets/Scripts/UI/Widgets/UIFactory.cs
@@ -1145,6 +1145,18 @@ namespace FantasyColony.UI.Widgets
             return dd;
         }
 
+        /// <summary>
+        /// Ensure the RectTransform has a raycast-target Graphic so pointer events hit it.
+        /// Adds an Image if no MaskableGraphic exists.
+        /// </summary>
+        public static void EnsureRaycastTarget(RectTransform rt)
+        {
+            if (rt == null) return;
+            var g = rt.GetComponent<MaskableGraphic>();
+            if (g == null) g = rt.gameObject.AddComponent<Image>();
+            g.raycastTarget = true;
+        }
+
     }
 
     // Stores actions for menu options created via AttachDropdownToButton


### PR DESCRIPTION
## Summary
- ensure panel surfaces have raycast-target graphics for editing
- add UIInstructionNote and InstructionDialog triggered with `I`
- expose currently selected RectTransform via UISelectionBox

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b914847ee4832489f1932c148b1b68