### PR TITLE
Add missing Widgets namespace to InstructionDialog

### DIFF
--- a/Assets/Scripts/UI/Creator/Editing/InstructionDialog.cs
+++ b/Assets/Scripts/UI/Creator/Editing/InstructionDialog.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using FantasyColony.UI.Widgets;
 
 namespace FantasyColony.UI.Creator.Editing
 {


### PR DESCRIPTION
## Summary
- include FantasyColony.UI.Widgets namespace in InstructionDialog

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b915fd2f2883249a737c98cf281f63