### PR TITLE
Add HitArea for panel selection and dragging

### DIFF
--- a/Assets/Scripts/UI/Creator/Editing/UIDragMove.cs
+++ b/Assets/Scripts/UI/Creator/Editing/UIDragMove.cs
@@ -21,6 +21,11 @@ namespace FantasyColony.UI.Creator.Editing
             if (_stage == null && _target != null) _stage = _target.parent as RectTransform;
         }
 
+        public void Init(RectTransform target, RectTransform stage)
+        {
+            _target = target; _stage = stage;
+        }
+
         public void OnBeginDrag(PointerEventData eventData)
         {
             if (_target == null || _stage == null) return;

--- a/Assets/Scripts/UI/Creator/Editing/UISelectionBox.cs
+++ b/Assets/Scripts/UI/Creator/Editing/UISelectionBox.cs
@@ -25,6 +25,11 @@ namespace FantasyColony.UI.Creator.Editing
             if (_stage == null) _stage = _target.parent as RectTransform;
         }
 
+        public void Init(RectTransform target, RectTransform stage)
+        {
+            _target = target; _stage = stage;
+        }
+
         public void OnPointerDown(PointerEventData eventData)
         {
             Select();

--- a/Assets/Scripts/UI/Screens/UICreatorScreen.cs
+++ b/Assets/Scripts/UI/Screens/UICreatorScreen.cs
@@ -309,8 +309,20 @@ namespace FantasyColony.UI.Screens
         {
             if (rt == null) return;
             if (rt.GetComponent<UIPixelSnap>() == null) rt.gameObject.AddComponent<UIPixelSnap>();
-            if (rt.GetComponent<UIDragMove>() == null) rt.gameObject.AddComponent<UIDragMove>();
-            if (rt.GetComponent<UISelectionBox>() == null) rt.gameObject.AddComponent<UISelectionBox>();
+
+            // Create a full-rect HitArea child to receive pointer events reliably
+            var hit = new GameObject("HitArea", typeof(RectTransform), typeof(Image));
+            var hitRT = hit.GetComponent<RectTransform>();
+            hitRT.SetParent(rt, false);
+            hitRT.anchorMin = Vector2.zero; hitRT.anchorMax = Vector2.one; hitRT.pivot = new Vector2(0.5f, 0.5f);
+            hitRT.offsetMin = Vector2.zero; hitRT.offsetMax = Vector2.zero;
+            var hitImg = hit.GetComponent<Image>(); hitImg.color = new Color(0,0,0,0); hitImg.raycastTarget = true;
+
+            var mover = hit.AddComponent<UIDragMove>();
+            mover.Init(rt, _stage);
+
+            var sel = hit.AddComponent<UISelectionBox>();
+            sel.Init(rt, _stage);
         }
 
         private void Update()


### PR DESCRIPTION
## Summary
- add `Init` method to `UIDragMove` and `UISelectionBox` for explicit target/stage assignment
- spawn a transparent `HitArea` child in `UICreatorScreen.AttachEditing` to forward drag and selection events to panels

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b917d871fc8324a76bf42ba45efe69