### PR TITLE
UICreator layout ignore for HitArea and SelectionOverlay

### DIFF
--- a/Assets/Scripts/UI/Creator/Editing/UISelectionBox.cs
+++ b/Assets/Scripts/UI/Creator/Editing/UISelectionBox.cs
@@ -54,6 +54,8 @@ namespace FantasyColony.UI.Creator.Editing
             _overlay.pivot = new Vector2(0, 1);
             _overlay.anchoredPosition = Vector2.zero;
             _overlay.sizeDelta = _target.rect.size;
+            var le = _overlay.gameObject.AddComponent<UnityEngine.UI.LayoutElement>(); le.ignoreLayout = true; // avoid VLG on panel root
+            _overlay.SetAsLastSibling();
 
             var border = _overlay.gameObject.AddComponent<UIFrame>();
             border.SetEdges(true, true, true, true);

--- a/Assets/Scripts/UI/Screens/UICreatorScreen.cs
+++ b/Assets/Scripts/UI/Screens/UICreatorScreen.cs
@@ -317,6 +317,7 @@ namespace FantasyColony.UI.Screens
             hitRT.anchorMin = Vector2.zero; hitRT.anchorMax = Vector2.one; hitRT.pivot = new Vector2(0.5f, 0.5f);
             hitRT.offsetMin = Vector2.zero; hitRT.offsetMax = Vector2.zero;
             var hitImg = hit.GetComponent<Image>(); hitImg.color = new Color(0,0,0,0); hitImg.raycastTarget = true;
+            var hitLE = hit.AddComponent<LayoutElement>(); hitLE.ignoreLayout = true; // do not be controlled by parent VLG
 
             var mover = hit.AddComponent<UIDragMove>();
             mover.Init(rt, _stage);


### PR DESCRIPTION
## Summary
- ensure HitArea ignores parent layout groups
- keep selection overlay from being affected by layout and render on top

## Testing
- ❌ `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b91df2d9ec8324b19168a3b634cba3