### PR TITLE
UICreator: add keyboard hotkeys handler

### DIFF
--- a/Assets/Scripts/UI/Creator/Editing/UICreatorHotkeys.cs
+++ b/Assets/Scripts/UI/Creator/Editing/UICreatorHotkeys.cs
@@ -1,0 +1,68 @@
+using System;
+using UnityEngine;
+
+namespace FantasyColony.UI.Creator.Editing
+{
+    /// <summary>
+    /// MonoBehaviour that captures keyboard shortcuts for the UI Creator.
+    /// Attach to the stage so Update() runs; delegates actions back to the screen.
+    /// </summary>
+    public sealed class UICreatorHotkeys : MonoBehaviour
+    {
+        private RectTransform _stage, _layerBG, _layerPanels, _layerControls;
+        private Action _onMenuRefresh;
+
+        public void Init(RectTransform stage, RectTransform layerBG, RectTransform layerPanels, RectTransform layerControls, Action onMenuRefresh)
+        {
+            _stage = stage; _layerBG = layerBG; _layerPanels = layerPanels; _layerControls = layerControls; _onMenuRefresh = onMenuRefresh;
+            Debug.Log("[UICreator] Hotkeys ready");
+        }
+
+        private void Update()
+        {
+            // Toggle grid (G) and cycle size (Ctrl+G)
+            if (Input.GetKeyDown(KeyCode.G))
+            {
+                bool ctrl = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+                if (ctrl)
+                {
+                    GridPrefs.CycleCellSize();
+                }
+                else
+                {
+                    GridPrefs.GridVisible = !GridPrefs.GridVisible;
+                    Debug.Log($"[UICreator] Grid {(GridPrefs.GridVisible ? "on" : "off")}");
+                }
+                _onMenuRefresh?.Invoke();
+            }
+
+            // Snap toggle (F4)
+            if (Input.GetKeyDown(KeyCode.F4))
+            {
+                GridPrefs.SnapEnabled = !GridPrefs.SnapEnabled;
+                Debug.Log($"[UICreator] Snap {(GridPrefs.SnapEnabled ? "on" : "off")}");
+            }
+
+            // Delete selected (Del/Backspace)
+            if (Input.GetKeyDown(KeyCode.Delete) || Input.GetKeyDown(KeyCode.Backspace))
+            {
+                var sel = UISelectionBox.CurrentTarget;
+                if (sel == null)
+                {
+                    Debug.Log("[UICreator] Delete: nothing selected");
+                    return;
+                }
+                if (sel == _stage || sel == _layerBG || sel == _layerPanels || sel == _layerControls)
+                {
+                    Debug.Log("[UICreator] Delete: refusing to delete stage/layer");
+                    return;
+                }
+                var name = sel.name;
+                Destroy(sel.gameObject);
+                Debug.Log($"[UICreator] Deleted: {name}");
+                _onMenuRefresh?.Invoke();
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/UI/Creator/Editing/UICreatorHotkeys.cs.meta
+++ b/Assets/Scripts/UI/Creator/Editing/UICreatorHotkeys.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9d13d7c1da474d5db816829567348e16
+

--- a/Assets/Scripts/UI/Screens/UICreatorScreen.cs
+++ b/Assets/Scripts/UI/Screens/UICreatorScreen.cs
@@ -125,6 +125,11 @@ namespace FantasyColony.UI.Screens
               Debug.Log($"[UICreator] Grid:on size={GridPrefs.CellSize}");
               EnsureLayers();
 
+              // Attach hotkeys component so keyboard shortcuts work even if this Screen is not a MonoBehaviour
+              var hk = _stage.gameObject.GetComponent<UICreatorHotkeys>();
+              if (hk == null) hk = _stage.gameObject.AddComponent<UICreatorHotkeys>();
+              hk.Init(_stage, _layerBackground, _layerPanels, _layerControls, RebuildViewMenu);
+
             // --- Toolbar content: equal-width buttons across full width ---
             // Create equal-width buttons directly under the toolbar (no nested Row)
             _btnFile  = CreateFlexMenuButton(_toolbar, "File",  OnFileMenu);


### PR DESCRIPTION
## Summary
- Add `UICreatorHotkeys` MonoBehaviour to process runtime keyboard shortcuts
- Attach hotkeys component to UI Creator stage so shortcuts work when screen isn't a MonoBehaviour

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b92c51e318832483674125fdd0b2e7