### PR TITLE
UICreator: centralize hotkeys & support dual input system

### DIFF
--- a/Assets/Scripts/UI/Creator/Editing/UICreatorHotkeys.cs
+++ b/Assets/Scripts/UI/Creator/Editing/UICreatorHotkeys.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 namespace FantasyColony.UI.Creator.Editing
 {
@@ -11,57 +12,88 @@ namespace FantasyColony.UI.Creator.Editing
     {
         private RectTransform _stage, _layerBG, _layerPanels, _layerControls;
         private Action _onMenuRefresh;
+        private Action _toggleFullscreen, _toggleGrid, _cycleGridSize, _toggleSnap, _deleteSelected;
+        private Func<bool> _canDelete;
 
-        public void Init(RectTransform stage, RectTransform layerBG, RectTransform layerPanels, RectTransform layerControls, Action onMenuRefresh)
+        public void Init(
+            RectTransform stage,
+            RectTransform layerBG,
+            RectTransform layerPanels,
+            RectTransform layerControls,
+            Action onMenuRefresh,
+            Action toggleFullscreen,
+            Action toggleGrid,
+            Action cycleGridSize,
+            Action toggleSnap,
+            Func<bool> canDelete,
+            Action deleteSelected)
         {
-            _stage = stage; _layerBG = layerBG; _layerPanels = layerPanels; _layerControls = layerControls; _onMenuRefresh = onMenuRefresh;
+            _stage = stage; _layerBG = layerBG; _layerPanels = layerPanels; _layerControls = layerControls;
+            _onMenuRefresh = onMenuRefresh;
+            _toggleFullscreen = toggleFullscreen; _toggleGrid = toggleGrid; _cycleGridSize = cycleGridSize; _toggleSnap = toggleSnap;
+            _canDelete = canDelete; _deleteSelected = deleteSelected;
             Debug.Log("[UICreator] Hotkeys ready");
         }
 
         private void Update()
         {
-            // Toggle grid (G) and cycle size (Ctrl+G)
+            // Don't fire hotkeys while typing into an InputField/TMP_InputField
+            var go = EventSystem.current != null ? EventSystem.current.currentSelectedGameObject : null;
+            if (go != null && (go.GetComponent<UnityEngine.UI.InputField>() != null || HasTMPInput(go))) return;
+
+#if ENABLE_INPUT_SYSTEM
+            var kb = UnityEngine.InputSystem.Keyboard.current;
+            if (kb == null) return;
+
+            // F11: fullscreen toggle
+            if (kb.f11Key != null && kb.f11Key.wasPressedThisFrame) { _toggleFullscreen?.Invoke(); return; }
+
+            // Ctrl+G cycles grid size, G toggles
+            bool ctrl = (kb.leftCtrlKey != null && kb.leftCtrlKey.isPressed) || (kb.rightCtrlKey != null && kb.rightCtrlKey.isPressed);
+            if (kb.gKey != null && kb.gKey.wasPressedThisFrame)
+            {
+                if (ctrl) _cycleGridSize?.Invoke(); else _toggleGrid?.Invoke();
+                _onMenuRefresh?.Invoke();
+                return;
+            }
+
+            // F4: snap toggle
+            if (kb.f4Key != null && kb.f4Key.wasPressedThisFrame) { _toggleSnap?.Invoke(); return; }
+
+            // Delete / Backspace
+            bool del = kb.deleteKey != null && kb.deleteKey.wasPressedThisFrame;
+            bool back = kb.backspaceKey != null && kb.backspaceKey.wasPressedThisFrame;
+            if (del || back)
+            {
+                if (_canDelete == null || _canDelete()) _deleteSelected?.Invoke();
+                return;
+            }
+#else
+            // Legacy Input path
+            if (Input.GetKeyDown(KeyCode.F11)) { _toggleFullscreen?.Invoke(); return; }
             if (Input.GetKeyDown(KeyCode.G))
             {
                 bool ctrl = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
-                if (ctrl)
-                {
-                    GridPrefs.CycleCellSize();
-                }
-                else
-                {
-                    GridPrefs.GridVisible = !GridPrefs.GridVisible;
-                    Debug.Log($"[UICreator] Grid {(GridPrefs.GridVisible ? "on" : "off")}");
-                }
+                if (ctrl) _cycleGridSize?.Invoke(); else _toggleGrid?.Invoke();
                 _onMenuRefresh?.Invoke();
+                return;
             }
-
-            // Snap toggle (F4)
-            if (Input.GetKeyDown(KeyCode.F4))
-            {
-                GridPrefs.SnapEnabled = !GridPrefs.SnapEnabled;
-                Debug.Log($"[UICreator] Snap {(GridPrefs.SnapEnabled ? "on" : "off")}");
-            }
-
-            // Delete selected (Del/Backspace)
+            if (Input.GetKeyDown(KeyCode.F4)) { _toggleSnap?.Invoke(); return; }
             if (Input.GetKeyDown(KeyCode.Delete) || Input.GetKeyDown(KeyCode.Backspace))
             {
-                var sel = UISelectionBox.CurrentTarget;
-                if (sel == null)
-                {
-                    Debug.Log("[UICreator] Delete: nothing selected");
-                    return;
-                }
-                if (sel == _stage || sel == _layerBG || sel == _layerPanels || sel == _layerControls)
-                {
-                    Debug.Log("[UICreator] Delete: refusing to delete stage/layer");
-                    return;
-                }
-                var name = sel.name;
-                Destroy(sel.gameObject);
-                Debug.Log($"[UICreator] Deleted: {name}");
-                _onMenuRefresh?.Invoke();
+                if (_canDelete == null || _canDelete()) _deleteSelected?.Invoke();
+                return;
             }
+#endif
+        }
+
+        private static bool HasTMPInput(GameObject go)
+        {
+#if TMP_PRESENT
+            return go.GetComponent<TMPro.TMP_InputField>() != null;
+#else
+            return false;
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- centralize UI Creator hotkeys into a dedicated component
- support both old and new input systems with proper fullscreen/grid/snap/delete actions
- ignore hotkeys while typing in input fields

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b93251962883249a0ab40a136864c2