### PR TITLE
Fix escaped quotes in UICreatorScreen hotkey logs

### DIFF
--- a/Assets/Scripts/UI/Screens/UICreatorScreen.cs
+++ b/Assets/Scripts/UI/Screens/UICreatorScreen.cs
@@ -134,11 +134,11 @@ namespace FantasyColony.UI.Screens
                   // F11
                   () => ToggleStageFullscreen(),
                   // G
-                  () => { GridPrefs.GridVisible = !GridPrefs.GridVisible; Debug.Log($"[UICreator] Grid {(GridPrefs.GridVisible ? \"on\" : \"off\")}"); },
+                  () => { GridPrefs.GridVisible = !GridPrefs.GridVisible; Debug.Log($"[UICreator] Grid {(GridPrefs.GridVisible ? "on" : "off")}"); },
                   // Ctrl+G
                   () => { GridPrefs.CycleCellSize(); },
                   // F4
-                  () => { GridPrefs.SnapEnabled = !GridPrefs.SnapEnabled; Debug.Log($"[UICreator] Snap {(GridPrefs.SnapEnabled ? \"on\" : \"off\")}"); },
+                  () => { GridPrefs.SnapEnabled = !GridPrefs.SnapEnabled; Debug.Log($"[UICreator] Snap {(GridPrefs.SnapEnabled ? "on" : "off")}"); },
                   // canDelete
                   () => { var sel = UISelectionBox.CurrentTarget; return sel != null && sel != _stage && sel != _layerBackground && sel != _layerPanels && sel != _layerControls; },
                   // deleteSelected


### PR DESCRIPTION
## Summary
- remove unnecessary escapes in grid visibility and snap state log messages

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba67d157608324898729c73d78ced9